### PR TITLE
Fix: dragging windows accross multiple displays

### DIFF
--- a/extension/dragHandler.js
+++ b/extension/dragHandler.js
@@ -409,6 +409,12 @@ export const DragHandler = GObject.registerClass({
              if (zone !== TileZone.NONE && zone !== this._currentZone) {
                  Logger.log(`Edge tiling: detected zone ${zone}`);
                  this._currentZone = zone;
+
+                 if (this._lastReorderMonitor != null && monitor !== this._lastReorderMonitor) {
+                     this.tilingManager.setDragRemainingSpace(null);
+                     this.tilingManager.tileWorkspaceWindows(workspace, this._draggedWindow, this._lastReorderMonitor, false, true);
+                 }
+                 this._lastReorderMonitor = monitor;
                  this.edgeTilingManager.setEdgeTilingActive(true, this._draggedWindow);
                  this.drawingManager.showTilePreview(zone, workArea, this._draggedWindow);
                  
@@ -447,6 +453,11 @@ export const DragHandler = GObject.registerClass({
                  this._lastReorderMonitor = monitor;
              } else if (zone === TileZone.NONE && monitor !== this._lastReorderMonitor) {
                  Logger.log(`Drag monitor changed to ${monitor} (fast drag skipped edge zone), restarting reorder`);
+
+                 if (this._lastReorderMonitor != null) {
+                     this.tilingManager.tileWorkspaceWindows(workspace, this._draggedWindow, this._lastReorderMonitor, false, true)
+                 }
+
                  this.tilingManager.tileWorkspaceWindows(workspace, this._draggedWindow, monitor);
                  this.reorderingManager.startDrag(this._draggedWindow);
                  this._lastReorderMonitor = monitor;

--- a/extension/dragHandler.js
+++ b/extension/dragHandler.js
@@ -32,6 +32,7 @@ export const DragHandler = GObject.registerClass({
         this._currentGrabOp = null;
         this._restoringFromEdgeTile = false;
         this._skipNextTiling = null;
+        this._lastReorderMonitor = null;
     }
 
     // Accessor shortcuts
@@ -169,6 +170,7 @@ export const DragHandler = GObject.registerClass({
             !(this.windowingManager.isMaximizedOrFullscreen(window))) {
             Logger.log(`_grabOpBeginHandler: calling startDrag for window ${window.get_id()}`);
             this.reorderingManager.startDrag(window);
+            this._lastReorderMonitor = global.display.get_current_monitor();
         }
     };
     
@@ -227,7 +229,7 @@ export const DragHandler = GObject.registerClass({
             if (isMoveGrabOp(grabpo) && this._currentZone !== TileZone.NONE) {
                 Logger.log(`Edge tiling: applying zone ${this._currentZone}`);
                 const workspace = window.get_workspace();
-                const monitor = window.get_monitor();
+                const monitor = global.display.get_current_monitor();
                 const workArea = workspace.get_work_area_for_monitor(monitor);
                 
                 const occupiedWindow = this.edgeTilingManager.getWindowInZone(this._currentZone, workspace, monitor);
@@ -278,7 +280,8 @@ export const DragHandler = GObject.registerClass({
             this.drawingManager.hideTilePreview();
             this._draggedWindow = null;
             this._currentZone = TileZone.NONE;
-            
+            this._lastReorderMonitor = null;
+
             this.tilingManager.clearDragRemainingSpace();
             
             this.edgeTilingManager.setEdgeTilingActive(false, null);
@@ -333,7 +336,7 @@ export const DragHandler = GObject.registerClass({
         
         if (this._currentZone !== TileZone.NONE) {
             const workspace = this._draggedWindow.get_workspace();
-            const monitor = this._draggedWindow.get_monitor();
+            const monitor = global.display.get_current_monitor();
             const workArea = workspace.get_work_area_for_monitor(monitor);
             
             Logger.log(`Applying zone ${this._currentZone} on button release`);
@@ -376,11 +379,11 @@ export const DragHandler = GObject.registerClass({
 
     _onDragPositionChanged() {
         if (!this._draggedWindow) return;
-        
-        const monitor = this._draggedWindow.get_monitor();
+
+        const [x, y] = global.get_pointer();
+        const monitor = global.display.get_current_monitor();
         const workspace = this._draggedWindow.get_workspace();
         const workArea = workspace.get_work_area_for_monitor(monitor);
-        const [x, y] = global.get_pointer();
         
         const zone = this.edgeTilingManager.detectZone(x, y, workArea, workspace);
         const isInZone = zone !== TileZone.NONE;
@@ -435,12 +438,18 @@ export const DragHandler = GObject.registerClass({
                  this.edgeTilingManager.setEdgeTilingActive(false, null);
                  this.drawingManager.hideTilePreview();
                  this.tilingManager.setDragRemainingSpace(null);
-                 
+
                  this.clearGhostWindows();
-                 
+
                  this.tilingManager.tileWorkspaceWindows(workspace, this._draggedWindow, monitor);
-                 
+
                  this.reorderingManager.startDrag(this._draggedWindow);
+                 this._lastReorderMonitor = monitor;
+             } else if (zone === TileZone.NONE && monitor !== this._lastReorderMonitor) {
+                 Logger.log(`Drag monitor changed to ${monitor} (fast drag skipped edge zone), restarting reorder`);
+                 this.tilingManager.tileWorkspaceWindows(workspace, this._draggedWindow, monitor);
+                 this.reorderingManager.startDrag(this._draggedWindow);
+                 this._lastReorderMonitor = monitor;
              }
              
              this._isPositionProcessing = false;

--- a/extension/reordering.js
+++ b/extension/reordering.js
@@ -66,7 +66,7 @@ export const ReorderingManager = GObject.registerClass({
         const { meta_window } = this._dragContext;
 
         let workspace = meta_window.get_workspace();
-        let monitor = meta_window.get_monitor();
+        let monitor = global.display.get_current_monitor();
         let workArea = workspace.get_work_area_for_monitor(monitor);
 
         let _cursor = global.get_pointer();
@@ -122,8 +122,14 @@ export const ReorderingManager = GObject.registerClass({
 
         Logger.log(`startDrag called for window ${meta_window.get_id()}`);
         let workspace = meta_window.get_workspace()
-        let monitor = meta_window.get_monitor();
+        let monitor = global.display.get_current_monitor();
         let meta_windows = this._windowingManager.getMonitorWorkspaceWindows(workspace, monitor);
+
+        // If the dragged window is on a different monitor (cursor crossed before window did),
+        // include it so layout computation can place it in the cursor monitor's mosaic.
+        if (!meta_windows.find(w => w.get_id() === meta_window.get_id())) {
+            meta_windows = [meta_window, ...meta_windows];
+        }
 
         if (this._animationsManager) {
             this._animationsManager.setDragging(true);
@@ -141,7 +147,7 @@ export const ReorderingManager = GObject.registerClass({
 
         this._tilingManager.applySwaps(workspace, nonEdgeTiledMetaWindows);
 
-        let descriptors = this._tilingManager.windowsToDescriptors(nonEdgeTiledMetaWindows, monitor);
+        let descriptors = this._tilingManager.windowsToDescriptors(nonEdgeTiledMetaWindows, monitor, meta_window);
 
         let remainingSpace = null;
         if (edgeTiledWindows.length > 0 && this._edgeTilingManager) {

--- a/extension/tiling.js
+++ b/extension/tiling.js
@@ -1130,7 +1130,7 @@ export const TilingManager = GObject.registerClass({
         meta_windows = meta_windows.filter(w => !WindowState.get(w, 'pendingInQueue'));
         
         // Exclude the reference window only if explicitly requested (for overflow scenarios)
-        if (window && excludeFromTiling && !this.isDragging) {
+        if (window && excludeFromTiling) {
             const windowId = window.get_id();
             meta_windows = meta_windows.filter(w => w.get_id() !== windowId);
         }
@@ -2432,3 +2432,4 @@ class Mask {
         }
     }
 }
+


### PR DESCRIPTION
## Description
This attempts to retile windows on a display as a window is getting dragged out. This PR also changes some of the current monitor detection to use the cursor instead of the window. 

### Fixes / Improvements
- [x] **Fix**: Monitor not retiling window after a window is dragged out
- [x] **Fix**: Current monitor detection that now uses the monitor of the cursor where the cursor position is used to calculate things like edge tiling. 

## Related Issues
Closes #56 

## Validation
- [x] Validated in multi display environment. 

## Screenshots / Videos

Before:

https://github.com/user-attachments/assets/00f1b33c-2251-43e7-95fd-28debb2ea540

After:

https://github.com/user-attachments/assets/0978c0fd-0176-4d05-8647-649cec6e90ec

