### PR TITLE
Refactor maximize behavior to displace windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - run: pip install shexli
+      # tree-sitter 0.26 breaks ABI with the 0.25 javascript grammar shexli ships, which segfaults the parser
+      - run: pip install shexli "tree-sitter<0.26"
       - run: shexli ${{ github.workspace }}/extension/
 
   build:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,103 @@
+# Mosaic WM - Claude Code Guidelines
+
+## Project Overview
+
+GNOME Shell extension that provides automatic mosaic window tiling. Written in GJS (GNOME JavaScript) using ESM modules. Supports GNOME Shell 45–50.
+
+## Project Structure
+
+```
+extension/          # All extension source code (JS, CSS, icons, schemas)
+  extension.js      # Main controller — signal handling, state management
+  windowHandler.js  # Window lifecycle (creation, removal, geometry)
+  dragHandler.js    # Drag/grab operations (mouse + keyboard move)
+  reordering.js     # Drag reordering within mosaic
+  tiling.js         # Layout calculation, window positioning, overflow
+  windowing.js      # Window queries (exclusion, monitor, workspace)
+  edgeTiling.js     # Edge zone detection and snap-to-edge
+  resizeHandler.js  # Resize operations (manual + smart resize)
+  animations.js     # Smooth transitions
+  drawing.js        # Visual overlays (preview boxes)
+  swapping.js       # Window swap logic
+  overviewLayout.js # Overview mosaic layout strategy
+  constants.js      # Shared constants and enums
+  windowState.js    # Per-window state (WeakMap-based flags)
+  logger.js         # Debug logging (DEBUG flag)
+  timing.js         # Timing utilities
+  quickSettings.js  # Quick settings toggle
+  settingsOverrider.js # GSettings overrides
+  metadata.json     # Extension metadata
+scripts/            # Build and test scripts
+.local/             # Internal docs (BEHAVIOR.md, ARCHITECTURE.md) — NOT committed
+.agent/             # Agent workflows — NOT committed
+```
+
+## Build & Test
+
+```bash
+# Build and install
+flatpak-spawn --host bash -c './scripts/build.sh -i'
+
+# Build only (no install)
+flatpak-spawn --host bash -c './scripts/build.sh -b'
+
+# Run nested GNOME Shell for testing
+flatpak-spawn --host bash -c './scripts/run-gnome-shell.sh'
+```
+
+**WARNING**: Never use `kill`, `pkill`, or `killall gnome-shell` — it will terminate the host session.
+
+## Code Conventions
+
+- **ESM imports only**: `import Foo from 'gi://Foo';` — never `imports.gi.Foo`
+- **GObject pattern**: All managers use `GObject.registerClass` with `_init()`/`destroy()` lifecycle
+- **Signal-driven**: Use GObject signals and Meta.Window signals — no polling loops
+- **Logging**: Use `Logger.log()` / `Logger.error()` — never raw `console.log`
+- **Constants**: All magic numbers go in `constants.js`
+- **Window state**: Per-window flags via `WindowState.set()`/`WindowState.get()` (WeakMap)
+
+## Commit Rules
+
+- **No AI Co-Author tags**: Never include `Co-Authored-By` referencing Claude, Copilot, or any AI
+- **No AI-like comments**: Comments explain the WHY technically, never reference user requests or AI interaction
+- **Only commit `extension/`, `scripts/`, `schemas/`** — never `.agent/`, `.local/`, or log files
+- **Never use `git add .` or `git add -A`**
+- **Keep `DEBUG = true`** in logger.js unless explicitly doing a release
+
+## Pre-Commit Checklist
+
+**MANDATORY before every commit** — run `.agent/workflows/pre-commit.md`. Key checks:
+1. No unused imports, dead code, or commented-out blocks
+2. No deprecated modules (Lang, Mainloop, ByteArray)
+3. No GTK imports in extension.js
+4. No excessive blank lines or trailing whitespace
+5. Build passes without errors
+6. Behavior patterns from `.local/BEHAVIOR.md` remain intact
+7. Architecture changes documented in `.local/ARCHITECTURE.md`
+8. Read every modified file manually and verify comment quality (grep alone is not enough)
+
+## Comment Rules
+
+- **WHY only**: comments explain a non-obvious reason, constraint, or workaround — never what the code does
+- **Casual tone**: quick note from a teammate, not API docs
+- **No dash-as-connector**: no ` - ` or `—` joining two clauses in comments or log strings; use a period, semicolon, "since", "because", or parentheses
+- **No over-explaining**: if removing a sentence wouldn't confuse a future reader, remove it; match length to the nearest sibling comment
+- **No AI/task references**: never mention the user's request, issue numbers, or the AI interaction
+- **Grep before committing**: `grep -n " - " extension/*.js | grep "//"` must return empty
+- **Don't make a "fix comments" commit**: fold comment cleanup silently into the commit that touches that code
+
+## Key Architectural Patterns
+
+- **Coordinated Pause**: During drag, `Extension.js` controls `ReorderingManager.setPaused()` to prevent conflicts between edge tiling and reordering
+- **Sacred Window State Machine**: Two-stage resize-first strategy for unmaximize — window shrinks in isolation, then moves to destination
+- **Smart Resize Iterator**: Democratic proportional shrinking before overflow — iterative with abort support
+- **Producer-Consumer Queue**: Sequential window evaluation via `_evaluationQueue` to prevent race conditions
+- **Throttled Visual Updates**: High-frequency signals throttled via `GLib.idle_add` pattern
+
+## GNOME Shell Extension Rules (ego review)
+
+- Nothing before `enable()` — no object creation, signal connections, or Shell modifications
+- `disable()` must clean up everything done in `enable()`
+- All `GLib.timeout_add`/`GLib.idle_add` must be removed in `disable()`
+- Never import Gdk/Gtk/Adw in extension.js (only in prefs.js)
+- Never import Clutter/Meta/St/Shell in prefs.js

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -19,6 +19,8 @@ export default [
  rules: {
  // Style — matching existing codebase patterns
  'indent': ['error', 4, { SwitchCase: 1 }],
+ 'no-tabs': 'error',
+ 'no-trailing-spaces': 'error',
  'quotes': ['error', 'single', { avoidEscape: true }],
  'semi': ['error', 'always'],
  'comma-dangle': ['error', 'only-multiline'],

--- a/extension/constants.js
+++ b/extension/constants.js
@@ -68,6 +68,7 @@ export const MINIATURE_TARGET_SIZE_PX = 256;  // Longest side of a miniaturized 
 export const MINIATURE_ANIM_MS = 250;
 export const MINIATURE_FOCUS_GUARD_MS = 500;  // Block focus-triggered restore right after miniaturizing
 export const NEW_WINDOW_MINIATURIZE_PROTECTION_MS = 2000;  // Shield a just-opened window from being chosen as the miniaturize target
+export const DND_MINIATURE_RESTORE_DELAY_MS = 400;  // Dwell time over a miniature before a DnD hover triggers restore
 
 // Compact the per-workspace swap history into a single canonical order op
 // once it grows past this many entries (keeps replay cost bounded)

--- a/extension/constants.js
+++ b/extension/constants.js
@@ -70,6 +70,10 @@ export const MINIATURE_FOCUS_GUARD_MS = 500;  // Block focus-triggered restore r
 export const NEW_WINDOW_MINIATURIZE_PROTECTION_MS = 2000;  // Shield a just-opened window from being chosen as the miniaturize target
 export const DND_MINIATURE_RESTORE_DELAY_MS = 400;  // Dwell time over a miniature before a DnD hover triggers restore
 
+// Restored window's distance to its old slot is the primary layout pick; layouts
+// whose distances land within this many px tie, so shelves still break near-ties.
+export const RESTORE_PROXIMITY_TOLERANCE_PX = 100;
+
 // Compact the per-workspace swap history into a single canonical order op
 // once it grows past this many entries (keeps replay cost bounded)
 export const SWAP_OPS_COMPACT_THRESHOLD = 8;

--- a/extension/constants.js
+++ b/extension/constants.js
@@ -40,6 +40,7 @@ export const REVERSE_RESIZE_PROTECTION_MS = 1000; // Protection window for rever
 export const RESIZE_SETTLE_DELAY_MS = 150;       // Delay to let Mutter apply resize before retiling
 export const RESIZE_CLAMP_SETTLE_WINDOW_MS = 1500; // Window age below which a clamp is treated as the client still settling
 export const RESIZE_CLAMP_RETRY_DELAY_MS = 200;  // Delay before retrying a clamped resize once
+export const SMART_RESIZE_CLAMP_MIN_SHRINK_PX = 8; // A window sized within this of its pre-resize size never really clamped, so don't remember it as a minimum
 export const ISRESIZING_FLAG_RESET_MS = 2;
 // Mutter can skip the size-changed confirmation on a fast maximize/unmaximize
 // toggle, so force the move after this long instead of leaving the window stuck.

--- a/extension/constants.js
+++ b/extension/constants.js
@@ -4,6 +4,16 @@
 
 export const WINDOW_SPACING = 8; // Pixels
 
+// Cap on distinct drag candidates kept after de-duplication so the live nearest search
+// stays cheap. A safety net that keeps the current layout, so it never drops a reachable one.
+export const MAX_DRAG_LAYOUTS = 48;
+// Wall-clock ceiling for composition generation at drag start; a last-resort guard
+// against pathological window counts.
+export const DRAG_LAYOUT_TIME_BUDGET_MS = 8;
+// A Super+Arrow only counts as an action if it moves the focused window's center at
+// least this far in the pressed direction; below it the key is a no-op.
+export const KEYBOARD_RECOMPOSE_MIN_DISPLACEMENT_PX = 20;
+
 export const WINDOW_VALIDITY_CHECK_INTERVAL_MS = 10;
 
 export const TileZone = Object.freeze({

--- a/extension/constants.js
+++ b/extension/constants.js
@@ -50,7 +50,6 @@ export const REVERSE_RESIZE_PROTECTION_MS = 1000; // Protection window for rever
 export const RESIZE_SETTLE_DELAY_MS = 150;       // Delay to let Mutter apply resize before retiling
 export const RESIZE_CLAMP_SETTLE_WINDOW_MS = 1500; // Window age below which a clamp is treated as the client still settling
 export const RESIZE_CLAMP_RETRY_DELAY_MS = 200;  // Delay before retrying a clamped resize once
-export const SMART_RESIZE_CLAMP_MIN_SHRINK_PX = 8; // A window sized within this of its pre-resize size never really clamped, so don't remember it as a minimum
 export const ISRESIZING_FLAG_RESET_MS = 2;
 // Mutter can skip the size-changed confirmation on a fast maximize/unmaximize
 // toggle, so force the move after this long instead of leaving the window stuck.

--- a/extension/dragHandler.js
+++ b/extension/dragHandler.js
@@ -65,6 +65,12 @@ export const DragHandler = GObject.registerClass({
     }
 
     _grabOpBeginHandler = (_display, window, grabpo) => {
+        // Keyboard-driven grabs (Alt+F8 resize, Alt+Tab+move) bypass the click overlay
+        // entirely, so a miniature would otherwise be manipulable without ever restoring.
+        if (WindowState.get(window, WindowState.IS_MINIATURE)) {
+            this._ext.miniatureManager?.restoreMiniature(window, null);
+        }
+
         this._currentGrabOp = grabpo;
         const isResizeOp = isResizeGrabOp(grabpo);
         if (isResizeOp) {

--- a/extension/dragHandler.js
+++ b/extension/dragHandler.js
@@ -21,7 +21,7 @@ export const DragHandler = GObject.registerClass({
     _init(extension) {
         super._init();
         this._ext = extension;
-        
+
         // Drag state
         this._draggedWindow = null;
         this._edgeTileGhostWindows = [];
@@ -76,43 +76,43 @@ export const DragHandler = GObject.registerClass({
         if (isResizeOp) {
             this._ext.resizeHandler.onResizeBegin(window, grabpo);
         }
-        
+
         if (isMoveGrabOp(grabpo) && !this.windowingManager.isExcluded(window)) {
             const workspace = window.get_workspace();
             if (workspace && this._ext && !this._ext.isMosaicEnabledForWorkspace(workspace))
                 return;
             Logger.log('Edge tiling: grab begin');
             this._draggedWindow = window;
-            
+
             const windowState = this.edgeTilingManager.getWindowState(window);
-            
+
             // Initialize _currentZone with window's zone if it's already edge-tiled
             if (windowState && windowState.zone !== TileZone.NONE) {
                 this._currentZone = windowState.zone;
                 Logger.log(`Edge tiling: window was in zone ${windowState.zone}, initializing _currentZone`);
-                
+
                 this._skipNextTiling = window.get_id();
                 this._restoringFromEdgeTile = true;
-                
+
                 this.edgeTilingManager.removeTile(window, () => {
                     // Delay clearing the flag to cover the debounce period for overflow detection
                     this._timeoutRegistry.add(constants.EDGE_TILE_RESTORE_DELAY_MS, () => {
                         this._restoringFromEdgeTile = false;
                         return GLib.SOURCE_REMOVE;
                     }, 'dragHandler_edgeTileRestoreDelay');
-                    
+
                     Logger.log('Edge tiling: restoration complete, checking if drag still active');
                     this._skipNextTiling = null;
                     this._currentZone = TileZone.NONE; // Reset so window doesn't get re-tiled on release
-                    
+
                     // Check if button was already released during restoration
                     const [_x, _y, mods] = global.get_pointer();
                     const isButtonPressed = (mods & Clutter.ModifierType.BUTTON1_MASK) !== 0;
-                    
+
                     if (!isButtonPressed) {
                         Logger.log('Edge tiling: button released during restoration, skipping startDrag');
                         this._draggedWindow = null;
-                        
+
                         // Retile the workspace so the window returns to mosaic position
                         const workspace = window.get_workspace();
                         const monitor = window.get_monitor();
@@ -130,7 +130,7 @@ export const DragHandler = GObject.registerClass({
                         const workspace = window.get_workspace();
                         const monitor = window.get_monitor();
                         const fits = this.tilingManager.canFitWindow(window, workspace, monitor, true);
-                         
+
                         if (!fits) {
                             Logger.log('Edge tile exit: window doesn\'t fit - applying overflow opacity');
                             const actor = window.get_compositor_private();
@@ -151,7 +151,7 @@ export const DragHandler = GObject.registerClass({
             } else {
                 this._currentZone = TileZone.NONE;
             }
-            
+
             // Drive edge-tiling detection from Mutter's position-changed signal
             Logger.log('Connecting signal-based edge tiling listeners');
             this._dragPositionChangedId = this._draggedWindow.connect('position-changed', this._onDragPositionChanged.bind(this));
@@ -174,20 +174,20 @@ export const DragHandler = GObject.registerClass({
             this._lastReorderMonitor = global.display.get_current_monitor();
         }
     };
-    
+
     _grabOpEndHandler = (_display, window, grabpo) => {
         this._currentGrabOp = null;
-        
+
         // Handle drag overflow - window that was marked as not fitting
         if (this._dragOverflowWindow && this._dragOverflowWindow === window) {
             Logger.log('Drag ended with overflow window - moving to new workspace');
             const actor = this._dragOverflowWindow.get_compositor_private();
             if (actor) actor.opacity = 255; // Restore opacity
-            
+
             this.tilingManager.clearExcludedWindow();
             this.drawingManager.hideTilePreview();
             this.drawingManager.removeBoxes();
-            
+
             const oldWorkspace = window.get_workspace();
             this.windowingManager.moveOversizedWindow(window).catch(e =>
                 Logger.error(`Drag overflow failed: ${e}`));
@@ -197,11 +197,11 @@ export const DragHandler = GObject.registerClass({
                     this.tilingManager.tileWorkspaceWindows(oldWorkspace, null, monitor, false);
                 }
             }, this._timeoutRegistry);
-            
+
             this._dragOverflowWindow = null;
             this._draggedWindow = null;
             this._currentZone = TileZone.NONE;
-            
+
             if (this._dragPositionChangedId && window) {
                 try {
                     window.disconnect(this._dragPositionChangedId);
@@ -212,7 +212,7 @@ export const DragHandler = GObject.registerClass({
             }
             return;
         }
-        
+
         if ((isMoveGrabOp(grabpo) || grabpo === Meta.GrabOp.KEYBOARD_MOVING) && window === this._draggedWindow) {
             if (this._dragPositionChangedId && window) {
                 try {
@@ -289,13 +289,13 @@ export const DragHandler = GObject.registerClass({
             this._lastReorderMonitor = null;
 
             this.tilingManager.clearDragRemainingSpace();
-            
+
             this.edgeTilingManager.setEdgeTilingActive(false, null);
-            
+
             // Failsafe: Always clear ghost windows on drag end
             this.clearGhostWindows();
         }
-        
+
         if (!this.windowingManager.isExcluded(window)) {
             const skipTiling = this._skipNextTiling === window.get_id();
             const isResizeEnd = isResizeGrabOp(grabpo);
@@ -308,10 +308,10 @@ export const DragHandler = GObject.registerClass({
             if (isResizeEnd) {
                 this._ext.resizeHandler.onResizeEnd(window, grabpo, skipTiling);
             }
-            
+
             if ( (isMoveGrabOp(grabpo) || grabpo === Meta.GrabOp.KEYBOARD_MOVING) &&
                 !(this.windowingManager.isMaximizedOrFullscreen(window)) &&
-                !skipTiling) 
+                !skipTiling)
             {
                 afterAnimations(this.animationsManager, () => {
                     this.tilingManager.tileWorkspaceWindows(window.get_workspace(), window, window.get_monitor(), false);
@@ -320,7 +320,7 @@ export const DragHandler = GObject.registerClass({
         } else {
             this.reorderingManager.stopDrag(window, true);
         }
-        
+
         // UNCONDITIONAL CLEANUP
         this.clearGhostWindows();
         this.drawingManager.hideTilePreview();
@@ -333,10 +333,10 @@ export const DragHandler = GObject.registerClass({
         const monitor = global.display.get_current_monitor();
         const workspace = this._draggedWindow.get_workspace();
         const workArea = workspace.get_work_area_for_monitor(monitor);
-        
+
         const zone = this.edgeTilingManager.detectZone(x, y, workArea, workspace);
         const isInZone = zone !== TileZone.NONE;
-        
+
         // _currentZone is updated one idle after zone detection; without the guard the synchronous
         // path would draw a reordering rect over the tile-preview overlay on zone entry.
         if (this.reorderingManager) {
@@ -349,13 +349,13 @@ export const DragHandler = GObject.registerClass({
         // THROTTLED VISUAL UPDATE
         if (this._isPositionProcessing) return;
         this._isPositionProcessing = true;
-        
+
         this._timeoutRegistry.addIdle(() => {
             if (!this._draggedWindow) {
                 this._isPositionProcessing = false;
                 return GLib.SOURCE_REMOVE;
             }
-             
+
             if (zone !== TileZone.NONE && zone !== this._currentZone) {
                 Logger.log(`Edge tiling: detected zone ${zone}`);
                 this._currentZone = zone;
@@ -367,16 +367,16 @@ export const DragHandler = GObject.registerClass({
                 this._lastReorderMonitor = monitor;
                 this.edgeTilingManager.setEdgeTilingActive(true, this._draggedWindow);
                 this.drawingManager.showTilePreview(zone, workArea, this._draggedWindow);
-                 
+
                 const remainingSpace = this.edgeTilingManager.calculateRemainingSpaceForZone(zone, workArea);
                 this.tilingManager.setDragRemainingSpace(remainingSpace);
-                 
+
                 this.clearGhostWindows();
-                 
+
                 const mosaicWindows = this.windowingManager.getMonitorWorkspaceWindows(workspace, monitor)
-                    .filter(w => w.get_id() !== this._draggedWindow.get_id() && 
+                    .filter(w => w.get_id() !== this._draggedWindow.get_id() &&
                                  !this.edgeTilingManager.isEdgeTiled(w));
-                 
+
                 const result = this.tilingManager.tileWorkspaceWindows(workspace, this._draggedWindow, monitor, false);
 
                 if (result?.overflow) {
@@ -439,7 +439,7 @@ export const DragHandler = GObject.registerClass({
                 this.reorderingManager.startDrag(this._draggedWindow);
                 this._lastReorderMonitor = monitor;
             }
-             
+
             this._isPositionProcessing = false;
             return GLib.SOURCE_REMOVE;
         });

--- a/extension/drawing.js
+++ b/extension/drawing.js
@@ -16,10 +16,10 @@ export const DrawingManager = GObject.registerClass({
         this._boxes = [];
         // Pool of reusable boxes (avoids create/destroy churn)
         this._boxPool = [];
-        
+
         // Tile preview overlay for edge tiling
         this._tilePreview = null;
-        
+
         this._edgeTilingManager = null;
     }
 
@@ -34,16 +34,16 @@ export const DrawingManager = GObject.registerClass({
             box = this._boxPool.pop();
             box.show();
         } else {
-            box = new St.Widget({ 
+            box = new St.Widget({
                 style_class: 'mosaic-preview',
                 opacity: 200 // Ensure it's visible
             });
             Main.uiGroup.add_child(box);
         }
-        
+
         box.set_position(x, y);
         box.set_size(w, h);
-        
+
         this._boxes.push(box);
     }
 
@@ -59,15 +59,15 @@ export const DrawingManager = GObject.registerClass({
     showTilePreview(zone, workArea, window = null) {
         // Hide mosaic preview when showing edge tiling preview
         this.removeBoxes();
-        
+
         if (!this._edgeTilingManager) {
             Logger.warn('showTilePreview: EdgeTilingManager not set');
             return;
         }
-        
+
         const rect = this._edgeTilingManager.getZoneRect(zone, workArea, window);
         if (!rect) return;
-        
+
         if (!this._tilePreview) {
             this._tilePreview = new St.Widget({
                 style_class: 'tile-preview',
@@ -75,7 +75,7 @@ export const DrawingManager = GObject.registerClass({
             });
             Main.uiGroup.add_child(this._tilePreview);
         }
-        
+
         this._tilePreview.set_position(rect.x, rect.y);
         this._tilePreview.set_size(rect.width, rect.height);
         this._tilePreview.show();

--- a/extension/edgeTiling.js
+++ b/extension/edgeTiling.js
@@ -411,7 +411,7 @@ export const EdgeTilingManager = GObject.registerClass({
             w.zone === TileZone.TOP_RIGHT || w.zone === TileZone.BOTTOM_RIGHT
         );
 
-        
+
         if (hasLeftFull || hasLeftQuarters) {
             // Find the rightmost edge of all left-tiled windows
             let maxRight = workArea.x;
@@ -453,7 +453,7 @@ export const EdgeTilingManager = GObject.registerClass({
 
     calculateRemainingSpaceForZone(zone, workArea) {
         const halfWidth = Math.floor(workArea.width / 2);
-        
+
         switch (zone) {
             case TileZone.LEFT_FULL:
             case TileZone.TOP_LEFT:
@@ -869,7 +869,7 @@ export const EdgeTilingManager = GObject.registerClass({
 
         const savedWidth = savedState.width;
         const savedHeight = savedState.height;
-        
+
         Logger.log(`removeTile: Checking dependencies for master=${winId}`);
         const dependents = WindowState.get(window, 'autoTileDependents');
         if (dependents && dependents.size > 0) {

--- a/extension/extension.js
+++ b/extension/extension.js
@@ -27,7 +27,7 @@ import { SwappingManager } from './swapping.js';
 import { DrawingManager } from './drawing.js';
 import { AnimationsManager } from './animations.js';
 import { MosaicLayoutStrategy } from './overviewLayout.js';
-import { TimeoutRegistry, afterAnimations, afterOverviewHidden } from './timing.js';
+import { TimeoutRegistry, createDebounced, afterAnimations, afterOverviewHidden } from './timing.js';
 import { WindowHandler } from './windowHandler.js';
 import { DragHandler } from './dragHandler.js';
 import { ResizeHandler } from './resizeHandler.js';
@@ -77,7 +77,7 @@ export default class WindowMosaicExtension extends Extension {
         this._dndPositionId = 0;
         this._dndLeaveId = 0;
         this._dndActive = false;
-        this._dndRestoreTimer = null;
+        this._dndScheduleRestore = null;
         this._dndPendingWindowId = null;
 
         this._injectionManager = null;
@@ -262,6 +262,15 @@ export default class WindowMosaicExtension extends Extension {
 
         this._dnd = global.backend?.get_dnd() ?? null;
         if (this._dnd) {
+            this._dndScheduleRestore = createDebounced(
+                (window) => {
+                    this._dndPendingWindowId = null;
+                    if (isWindowAlive(window) && WindowState.get(window, WindowState.IS_MINIATURE))
+                        this.miniatureManager?.restoreMiniature(window, null);
+                },
+                constants.DND_MINIATURE_RESTORE_DELAY_MS,
+                this._timeoutRegistry
+            );
             this._dndEnterId = this._dnd.connect('dnd-enter', this._onDndEnter.bind(this));
             this._dndPositionId = this._dnd.connect('dnd-position-change', this._onDndPositionChange.bind(this));
             this._dndLeaveId = this._dnd.connect('dnd-leave', this._onDndLeave.bind(this));
@@ -575,10 +584,7 @@ export default class WindowMosaicExtension extends Extension {
 
     _onMiniatureRestored(window) {
         if (this._dndPendingWindowId === window.get_id()) {
-            if (this._dndRestoreTimer !== null) {
-                this._timeoutRegistry.remove(this._dndRestoreTimer);
-                this._dndRestoreTimer = null;
-            }
+            this._dndScheduleRestore?.cancel();
             this._dndPendingWindowId = null;
         }
         Logger.log(`[FOCUS] _onMiniatureRestored ${window.get_id()} (${window.get_wm_class?.() ?? '?'}): running smart resize`);
@@ -659,35 +665,17 @@ export default class WindowMosaicExtension extends Extension {
         const window = this.miniatureManager.findMiniatureAtPoint(x, y);
         if (window) {
             if (this._dndPendingWindowId === window.get_id()) return;
-            if (this._dndRestoreTimer !== null) {
-                this._timeoutRegistry.remove(this._dndRestoreTimer);
-                this._dndRestoreTimer = null;
-            }
             this._dndPendingWindowId = window.get_id();
-            this._dndRestoreTimer = this._timeoutRegistry.add(
-                constants.DND_MINIATURE_RESTORE_DELAY_MS,
-                () => {
-                    this._dndRestoreTimer = null;
-                    this._dndPendingWindowId = null;
-                    if (isWindowAlive(window) && WindowState.get(window, WindowState.IS_MINIATURE))
-                        this.miniatureManager?.restoreMiniature(window, null);
-                    return GLib.SOURCE_REMOVE;
-                },
-                'extension_dndMiniatureRestore'
-            );
-        } else if (this._dndRestoreTimer !== null) {
-            this._timeoutRegistry.remove(this._dndRestoreTimer);
-            this._dndRestoreTimer = null;
+            this._dndScheduleRestore(window);
+        } else {
+            this._dndScheduleRestore.cancel();
             this._dndPendingWindowId = null;
         }
     }
 
     _onDndLeave() {
         this._dndActive = false;
-        if (this._dndRestoreTimer !== null) {
-            this._timeoutRegistry?.remove(this._dndRestoreTimer);
-            this._dndRestoreTimer = null;
-        }
+        this._dndScheduleRestore?.cancel();
         this._dndPendingWindowId = null;
     }
 
@@ -847,10 +835,8 @@ export default class WindowMosaicExtension extends Extension {
             this._dndLeaveId = 0;
             this._dnd = null;
         }
-        if (this._dndRestoreTimer !== null) {
-            this._timeoutRegistry?.remove(this._dndRestoreTimer);
-            this._dndRestoreTimer = null;
-        }
+        this._dndScheduleRestore?.cancel();
+        this._dndScheduleRestore = null;
         this._dndActive = false;
         this._dndPendingWindowId = null;
 

--- a/extension/extension.js
+++ b/extension/extension.js
@@ -574,6 +574,13 @@ export default class WindowMosaicExtension extends Extension {
     }
 
     _onMiniatureRestored(window) {
+        if (this._dndPendingWindowId === window.get_id()) {
+            if (this._dndRestoreTimer !== null) {
+                this._timeoutRegistry.remove(this._dndRestoreTimer);
+                this._dndRestoreTimer = null;
+            }
+            this._dndPendingWindowId = null;
+        }
         Logger.log(`[FOCUS] _onMiniatureRestored ${window.get_id()} (${window.get_wm_class?.() ?? '?'}): running smart resize`);
         WindowState.remove(window, 'restoringFromMiniature');
         this.tilingManager._isSmartResizingBlocked = false;
@@ -662,7 +669,8 @@ export default class WindowMosaicExtension extends Extension {
                 () => {
                     this._dndRestoreTimer = null;
                     this._dndPendingWindowId = null;
-                    this.miniatureManager?.restoreMiniature(window, null);
+                    if (isWindowAlive(window) && WindowState.get(window, WindowState.IS_MINIATURE))
+                        this.miniatureManager?.restoreMiniature(window, null);
                     return GLib.SOURCE_REMOVE;
                 },
                 'extension_dndMiniatureRestore'

--- a/extension/extension.js
+++ b/extension/extension.js
@@ -306,6 +306,16 @@ export default class WindowMosaicExtension extends Extension {
             this._settingsOverrider.add(mutterKeybindings, 'toggle-tiled-right', emptyArray);
         }
 
+        const shellKeybindings = new Gio.Settings({ schema_id: 'org.gnome.shell.keybindings' });
+        // Super+Alt+Up/Down is our swap-up/down default but also GNOME's stock
+        // shift-overview-up/down, so clear GNOME's to keep the combo for recomposition.
+        if (shellKeybindings.get_strv('shift-overview-up').includes('<Super><Alt>Up')) {
+            this._settingsOverrider.add(shellKeybindings, 'shift-overview-up', emptyArray);
+        }
+        if (shellKeybindings.get_strv('shift-overview-down').includes('<Super><Alt>Down')) {
+            this._settingsOverrider.add(shellKeybindings, 'shift-overview-down', emptyArray);
+        }
+
         // Override Overview layout to preserve mosaic positions
         this._injectionManager = new InjectionManager();
 

--- a/extension/extension.js
+++ b/extension/extension.js
@@ -72,6 +72,14 @@ export default class WindowMosaicExtension extends Extension {
         this._focusWindowChangedId = 0;
         this._miniatureRestoredId  = 0;
 
+        this._dnd = null;
+        this._dndEnterId = 0;
+        this._dndPositionId = 0;
+        this._dndLeaveId = 0;
+        this._dndActive = false;
+        this._dndRestoreTimer = null;
+        this._dndPendingWindowId = null;
+
         this._injectionManager = null;
 
         // Centralized timeout management for async operations
@@ -137,7 +145,7 @@ export default class WindowMosaicExtension extends Extension {
     };
 
     // =========================================================================
-    // SIGNAL HANDLERS - Workspace Changes
+    // SIGNAL HANDLERS: Workspace Changes
     // =========================================================================
 
     _workspaceSwitchedHandler = () => {
@@ -251,6 +259,13 @@ export default class WindowMosaicExtension extends Extension {
             (_, window) => this._onMiniatureRestored(window));
         this._focusWindowChangedId = global.display.connect('notify::focus-window',
             () => this._onFocusWindowChanged());
+
+        this._dnd = global.backend?.get_dnd() ?? null;
+        if (this._dnd) {
+            this._dndEnterId = this._dnd.connect('dnd-enter', this._onDndEnter.bind(this));
+            this._dndPositionId = this._dnd.connect('dnd-position-change', this._onDndPositionChange.bind(this));
+            this._dndLeaveId = this._dnd.connect('dnd-leave', this._onDndLeave.bind(this));
+        }
 
         // Initialize Quick Settings indicator
         this._mosaicIndicator = new MosaicIndicator(this);
@@ -628,6 +643,46 @@ export default class WindowMosaicExtension extends Extension {
         }
     }
 
+    _onDndEnter() {
+        this._dndActive = true;
+    }
+
+    _onDndPositionChange(_dnd, x, y) {
+        if (!this._dndActive || !this.miniatureManager) return;
+        const window = this.miniatureManager.findMiniatureAtPoint(x, y);
+        if (window) {
+            if (this._dndPendingWindowId === window.get_id()) return;
+            if (this._dndRestoreTimer !== null) {
+                this._timeoutRegistry.remove(this._dndRestoreTimer);
+                this._dndRestoreTimer = null;
+            }
+            this._dndPendingWindowId = window.get_id();
+            this._dndRestoreTimer = this._timeoutRegistry.add(
+                constants.DND_MINIATURE_RESTORE_DELAY_MS,
+                () => {
+                    this._dndRestoreTimer = null;
+                    this._dndPendingWindowId = null;
+                    this.miniatureManager?.restoreMiniature(window, null);
+                    return GLib.SOURCE_REMOVE;
+                },
+                'extension_dndMiniatureRestore'
+            );
+        } else if (this._dndRestoreTimer !== null) {
+            this._timeoutRegistry.remove(this._dndRestoreTimer);
+            this._dndRestoreTimer = null;
+            this._dndPendingWindowId = null;
+        }
+    }
+
+    _onDndLeave() {
+        this._dndActive = false;
+        if (this._dndRestoreTimer !== null) {
+            this._timeoutRegistry?.remove(this._dndRestoreTimer);
+            this._dndRestoreTimer = null;
+        }
+        this._dndPendingWindowId = null;
+    }
+
     _setupKeybindings() {
         const settings = this.getSettings('org.gnome.shell.extensions.mosaic-wm');
 
@@ -774,6 +829,22 @@ export default class WindowMosaicExtension extends Extension {
             global.display.disconnect(this._focusWindowChangedId);
             this._focusWindowChangedId = 0;
         }
+
+        if (this._dnd) {
+            if (this._dndEnterId) this._dnd.disconnect(this._dndEnterId);
+            if (this._dndPositionId) this._dnd.disconnect(this._dndPositionId);
+            if (this._dndLeaveId) this._dnd.disconnect(this._dndLeaveId);
+            this._dndEnterId = 0;
+            this._dndPositionId = 0;
+            this._dndLeaveId = 0;
+            this._dnd = null;
+        }
+        if (this._dndRestoreTimer !== null) {
+            this._timeoutRegistry?.remove(this._dndRestoreTimer);
+            this._dndRestoreTimer = null;
+        }
+        this._dndActive = false;
+        this._dndPendingWindowId = null;
 
         if (this.miniatureManager) {
             // Disconnect listener first, otherwise restoreMiniature re-enters

--- a/extension/miniature.js
+++ b/extension/miniature.js
@@ -257,7 +257,7 @@ export const MiniatureManager = GObject.registerClass({
 }, class MiniatureManager extends GObject.Object {
     _init() {
         super._init();
-        this._miniatureWindows = new Set();
+        this._miniatureWindows = new Map();
         this._timeoutRegistry = null;
         this._animationsManager = null;
     }
@@ -428,7 +428,7 @@ export const MiniatureManager = GObject.registerClass({
             WindowState.set(window, 'miniatureJustMiniaturizedTimeoutId', timeoutId);
         }
 
-        this._miniatureWindows.add(window.get_id());
+        this._miniatureWindows.set(window.get_id(), window);
         this.emit('miniature-created', window);
 
         // Add click-capture overlay above the miniature
@@ -676,13 +676,8 @@ export const MiniatureManager = GObject.registerClass({
     }
 
     destroy() {
-        if (this._miniatureWindows.size > 0) {
-            const windows = global.display.get_tab_list(Meta.TabList.NORMAL, null);
-            for (const window of windows) {
-                if (this._miniatureWindows.has(window.get_id()))
-                    this.destroyMiniature(window);
-            }
-        }
+        for (const window of this._miniatureWindows.values())
+            this.destroyMiniature(window);
         this._miniatureWindows.clear();
         this._timeoutRegistry = null;
     }
@@ -693,9 +688,7 @@ export const MiniatureManager = GObject.registerClass({
 
     findMiniatureAtPoint(x, y) {
         if (this._miniatureWindows.size === 0) return null;
-        const windows = global.display.get_tab_list(Meta.TabList.NORMAL, global.workspace_manager.get_active_workspace());
-        for (const window of windows) {
-            if (!this._miniatureWindows.has(window.get_id())) continue;
+        for (const window of this._miniatureWindows.values()) {
             const tgt = WindowState.get(window, MINIATURE_TARGET_POS);
             const scale = WindowState.get(window, MINIATURE_SCALE);
             const preSize = WindowState.get(window, PRE_MINIATURE_SIZE);

--- a/extension/miniature.js
+++ b/extension/miniature.js
@@ -441,6 +441,8 @@ export const MiniatureManager = GObject.registerClass({
     }
 
     restoreMiniature(window, _newSlot, { activate = true } = {}) {
+        if (!WindowState.get(window, IS_MINIATURE)) return false;
+
         const windowActor = window.get_compositor_private();
 
         const frame = window.get_frame_rect();
@@ -691,7 +693,7 @@ export const MiniatureManager = GObject.registerClass({
 
     findMiniatureAtPoint(x, y) {
         if (this._miniatureWindows.size === 0) return null;
-        const windows = global.display.get_tab_list(Meta.TabList.NORMAL, null);
+        const windows = global.display.get_tab_list(Meta.TabList.NORMAL, global.workspace_manager.get_active_workspace());
         for (const window of windows) {
             if (!this._miniatureWindows.has(window.get_id())) continue;
             const tgt = WindowState.get(window, MINIATURE_TARGET_POS);

--- a/extension/miniature.js
+++ b/extension/miniature.js
@@ -124,7 +124,7 @@ const MiniatureEnforceEffect = GObject.registerClass({
         }
 
         if (WindowState.get(this._window, ANIMATING_MINIATURE)) {
-            // Animation controls transforms - don't interfere
+            // Animation controls transforms; don't interfere
             super.vfunc_paint(...args);
             return;
         }
@@ -275,7 +275,7 @@ export const MiniatureManager = GObject.registerClass({
         if (!windowActor) return false;
 
         // animateWindow's onStopped(false) leaves the window in AnimationsManager's tracking,
-        // expecting a new animateWindow call to clean up - but a miniature ease takes over
+        // expecting a new animateWindow call to clean up. A miniature ease takes over
         // instead, so nothing else would, and 'animations-completed' would never fire again.
         this._animationsManager?.removeAnimatingWindow(window.get_id());
 
@@ -290,14 +290,14 @@ export const MiniatureManager = GObject.registerClass({
         const currentFrame = window.get_frame_rect();
 
         // Buffer rect vs frame rect is a stable border offset; the actor's live position
-        // isn't - after back-to-back move_resize_frame calls (e.g. a restore cascade
+        // isn't. After back-to-back move_resize_frame calls (e.g. a restore cascade
         // re-miniaturizing siblings) the compositor lags, baking that stale gap into extLeft/extTop.
         const bufferRect = window.get_buffer_rect();
         const extLeft = currentFrame.x - bufferRect.x;
         const extTop = currentFrame.y - bufferRect.y;
         Logger.log(`[MINIATURE] createMiniature ${window.get_id()} (${window.get_wm_class?.() ?? '?'}): preFrame=(${preSize.x},${preSize.y} ${preSize.width}x${preSize.height}) slot=${Math.round(preSize.width * scale)}x${Math.round(preSize.height * scale)} currentFrame=(${currentFrame.x},${currentFrame.y} ${currentFrame.width}x${currentFrame.height}) actorBefore=(${actorBefore_x},${actorBefore_y}) target=(${targetX},${targetY}) scale=${scale.toFixed(4)} extLeft=${extLeft} extTop=${extTop}`);
 
-        // Store state BEFORE animation - enforce effect and workspace animation
+        // Store state BEFORE animation. Enforce effect and workspace animation
         // patch need to read these during the animation
         WindowState.set(window, IS_MINIATURE, true);
         WindowState.set(window, MINIATURE_SCALE, scale);
@@ -518,7 +518,7 @@ export const MiniatureManager = GObject.registerClass({
 
             // A retile can interrupt this mid-flight (it shares the actor with
             // animateWindow's own position ease). Rather than snap to full size,
-            // pick the scale-up back up from wherever it got cut off - position is
+            // pick the scale-up back up from wherever it got cut off; position is
             // already handed off to whatever interrupted us by this point.
             const continueScaleUp = (isFinished) => {
                 if (!windowActor || windowActor.is_destroyed()) return;
@@ -687,6 +687,27 @@ export const MiniatureManager = GObject.registerClass({
 
     getMiniatureSize(window) {
         return getMiniatureSize(window);
+    }
+
+    findMiniatureAtPoint(x, y) {
+        if (this._miniatureWindows.size === 0) return null;
+        const windows = global.display.get_tab_list(Meta.TabList.NORMAL, null);
+        for (const window of windows) {
+            if (!this._miniatureWindows.has(window.get_id())) continue;
+            const tgt = WindowState.get(window, MINIATURE_TARGET_POS);
+            const scale = WindowState.get(window, MINIATURE_SCALE);
+            const preSize = WindowState.get(window, PRE_MINIATURE_SIZE);
+            const extL = WindowState.get(window, MINIATURE_EXT_LEFT) ?? 0;
+            const extT = WindowState.get(window, MINIATURE_EXT_TOP) ?? 0;
+            if (!tgt || !scale || !preSize) continue;
+            const ox = tgt.x - extL * scale;
+            const oy = tgt.y - extT * scale;
+            const ow = preSize.width * scale;
+            const oh = preSize.height * scale;
+            if (x >= ox && x <= ox + ow && y >= oy && y <= oy + oh)
+                return window;
+        }
+        return null;
     }
 });
 

--- a/extension/miniature.js
+++ b/extension/miniature.js
@@ -565,6 +565,16 @@ export const MiniatureManager = GObject.registerClass({
             });
         }
 
+        // Snapshot the slot center before the fields below get cleared, so the
+        // layout scorer can pull the restored window back near where it sat.
+        const anchorPre = WindowState.get(window, PRE_MINIATURE_SIZE);
+        if (tgt && anchorPre) {
+            const cx = tgt.x + (anchorPre.width * sc) / 2;
+            const cy = tgt.y + (anchorPre.height * sc) / 2;
+            WindowState.set(window, 'restoreAnchorCenter', { cx, cy });
+            Logger.log(`[RESTORE ANCHOR] ${window.get_id()}: slot center (${cx.toFixed(0)},${cy.toFixed(0)})`);
+        }
+
         // Clear remaining WindowState
         WindowState.remove(window, MINIATURE_SCALE);
         WindowState.remove(window, PRE_MINIATURE_SIZE);

--- a/extension/overviewLayout.js
+++ b/extension/overviewLayout.js
@@ -19,7 +19,7 @@ export class MosaicLayoutStrategy extends Workspace.LayoutStrategy {
 
     computeWindowSlots(layout, area) {
         const clones = layout.windows;
-        
+
         if (!area || clones.length === 0) {
             return [];
         }
@@ -32,7 +32,7 @@ export class MosaicLayoutStrategy extends Workspace.LayoutStrategy {
             if (metaWindow.get_transient_for() !== null) return false;
             return true;
         });
-        
+
         if (filteredClones.length === 0)
             return [];
 
@@ -45,7 +45,7 @@ export class MosaicLayoutStrategy extends Workspace.LayoutStrategy {
                 if (workspace) break;
             }
         }
-        
+
         if (!workspace) return [];
 
         // --- VIEWPORT MIRROR ---
@@ -74,7 +74,7 @@ export class MosaicLayoutStrategy extends Workspace.LayoutStrategy {
             // Secondary Fallback: Real Window Frame (ensures visibility if cache is missing)
             const rect = ComputedLayouts.get(mw) || mw.get_frame_rect();
             if (!rect) continue;
-            
+
             // Formula: (DesktopPos - DesktopOrigin) * Scale + OverviewSlotOrigin + CenteringOffset
             // Half-gap inset on each side → full WINDOW_SPACING between adjacent thumbnails
             const gap = WINDOW_SPACING / 2;
@@ -82,7 +82,7 @@ export class MosaicLayoutStrategy extends Workspace.LayoutStrategy {
             const y = (rect.y - workArea.y) * scale + area.y + offsetY + gap;
             const w = rect.width * scale - gap * 2;
             const h = rect.height * scale - gap * 2;
-            
+
             slots.push([x, y, w, h, clone]);
         }
 

--- a/extension/quickSettings.js
+++ b/extension/quickSettings.js
@@ -31,7 +31,7 @@ const MosaicMenuToggle = GObject.registerClass(
                 gicon: _getIcon(extension, 'mosaic-on-symbolic'),
                 toggleMode: true,
             });
-        
+
             this._extension = extension;
             this._workspaceItems = [];
 
@@ -40,31 +40,31 @@ const MosaicMenuToggle = GObject.registerClass(
             this.connect('clicked', () => {
                 this._onGlobalToggle();
             });
-        
+
             // Build the menu header
             this.menu.setHeader(_getIcon(extension, 'mosaic-on-symbolic'), 'Mosaic WM');
-        
+
             // Workspaces section
             this._workspacesSection = new PopupMenu.PopupMenuSection();
             this.menu.addMenuItem(this._workspacesSection);
-        
+
             // Connect to workspace signals
             this._workspaceManager = global.workspace_manager;
             this._wsAddedId = this._workspaceManager.connect('workspace-added', () => this._rebuildWorkspaceList());
             this._wsRemovedId = this._workspaceManager.connect('workspace-removed', () => this._rebuildWorkspaceList());
             this._wsSwitchedId = this._workspaceManager.connect('active-workspace-changed', () => this._updateCurrentWorkspaceHighlight());
-        
+
             // Build initial workspace list (after _workspaceManager is set)
             this._rebuildWorkspaceList();
         }
-    
+
         _onGlobalToggle() {
             const enabled = this.checked;
             const nWorkspaces = this._workspaceManager.get_n_workspaces();
             Logger.log(`Quick Settings: Global toggle ${enabled ? 'ON' : 'OFF'}`);
 
             this.gicon = _getIcon(this._extension, enabled ? 'mosaic-on-symbolic' : 'mosaic-off-symbolic');
-        
+
             if (enabled) {
             // Enable mosaic on all workspaces
             // For WeakMap, we iterate all workspaces and ensure they are NOT in the map (or false)
@@ -74,7 +74,7 @@ const MosaicMenuToggle = GObject.registerClass(
                         this._extension._disabledWorkspaceStates.delete(workspace);
                     }
                 }
-            
+
                 // Re-tile all workspaces (monitor detection is automatic)
                 for (let i = 0; i < nWorkspaces; i++) {
                     const workspace = this._workspaceManager.get_workspace_by_index(i);
@@ -95,69 +95,69 @@ const MosaicMenuToggle = GObject.registerClass(
                     }
                 }
             }
-        
+
             this._rebuildWorkspaceList();
             this._extension._updateIndicatorIcon();
         }
-    
+
         _rebuildWorkspaceList() {
             this._workspacesSection.removeAll();
             this._workspaceItems = [];
-        
+
             const nWorkspaces = this._workspaceManager.get_n_workspaces();
             const activeIndex = this._workspaceManager.get_active_workspace_index();
-        
+
             for (let i = 0; i < nWorkspaces; i++) {
                 const workspace = this._workspaceManager.get_workspace_by_index(i);
                 const isEnabled = workspace ? !this._extension._disabledWorkspaceStates.get(workspace) : true;
                 const isActive = i === activeIndex;
-            
+
                 const item = new PopupMenu.PopupSwitchMenuItem(
                     `Workspace ${i + 1}`,
                     isEnabled
                 );
-            
+
                 const icon = new St.Icon({
                     gicon: _getIcon(this._extension, 'dot-symbolic'),
                     style_class: 'popup-menu-icon',
                     y_align: Clutter.ActorAlign.CENTER,
                 });
                 icon.visible = isActive;
-            
+
                 // Insert after label (label is usually index 1 after ornament)
                 item.insert_child_at_index(icon, 2);
                 item._locationIcon = icon;
-            
+
                 item._workspaceIndex = i;
                 item.connect('toggled', (menuItem, state) => {
                     this._onWorkspaceToggle(menuItem._workspaceIndex, state);
                 });
-            
+
                 this._workspacesSection.addMenuItem(item);
                 this._workspaceItems.push(item);
             }
-        
+
             // Update global toggle state based on workspace states
             this._updateGlobalToggleState();
         }
-    
+
         _updateCurrentWorkspaceHighlight() {
             const activeIndex = this._workspaceManager.get_active_workspace_index();
             const nWorkspaces = this._workspaceManager.get_n_workspaces();
-        
+
             for (let i = 0; i < this._workspaceItems.length && i < nWorkspaces; i++) {
                 const item = this._workspaceItems[i];
                 const isActive = i === activeIndex;
-            
+
                 if (item._locationIcon) {
                     item._locationIcon.visible = isActive;
                 }
             }
-        
+
             // Update indicator icon for current workspace
             this._extension._updateIndicatorIcon();
         }
-    
+
         _onWorkspaceToggle(workspaceIndex, enabled) {
             Logger.log(`Quick Settings: Workspace ${workspaceIndex + 1} mosaic ${enabled ? 'ON' : 'OFF'}`);
 
@@ -184,12 +184,12 @@ const MosaicMenuToggle = GObject.registerClass(
                 }
             }
         }
-    
+
         _updateGlobalToggleState() {
         // Global toggle is ON if any workspace has mosaic enabled
             const nWorkspaces = this._workspaceManager.get_n_workspaces();
             let anyEnabled = false;
-        
+
             for (let i = 0; i < nWorkspaces; i++) {
                 const workspace = this._workspaceManager.get_workspace_by_index(i);
                 if (workspace && !this._extension._disabledWorkspaceStates.get(workspace)) {
@@ -197,11 +197,11 @@ const MosaicMenuToggle = GObject.registerClass(
                     break;
                 }
             }
-        
+
             this.checked = anyEnabled;
             this.gicon = _getIcon(this._extension, anyEnabled ? 'mosaic-on-symbolic' : 'mosaic-off-symbolic');
         }
-    
+
         destroy() {
             if (this._wsAddedId) {
                 this._workspaceManager.disconnect(this._wsAddedId);
@@ -215,7 +215,7 @@ const MosaicMenuToggle = GObject.registerClass(
                 this._workspaceManager.disconnect(this._wsSwitchedId);
                 this._wsSwitchedId = null;
             }
-        
+
             super.destroy();
         }
     });
@@ -225,38 +225,38 @@ export const MosaicIndicator = GObject.registerClass(
     class MosaicIndicator extends QuickSettings.SystemIndicator {
         constructor(extension) {
             super();
-        
+
             this._extension = extension;
-        
+
             // Create the indicator icon
             this._indicator = this._addIndicator();
             this._indicator.gicon = _getIcon(extension, 'mosaic-on-symbolic');
             this._indicator.visible = true;
-        
+
             // Create the toggle menu
             this._toggle = new MosaicMenuToggle(extension);
             this.quickSettingsItems.push(this._toggle);
-        
+
             // Connect to workspace switch to update icon
             this._workspaceManager = global.workspace_manager;
             this._wsSwitchedId = this._workspaceManager.connect('active-workspace-changed', () => {
                 this._updateIcon();
             });
         }
-    
+
         _updateIcon() {
             const activeIndex = this._workspaceManager.get_active_workspace_index();
             const workspace = this._workspaceManager.get_workspace_by_index(activeIndex);
             const isEnabled = workspace ? !this._extension._disabledWorkspaceStates.get(workspace) : true;
             this._indicator.gicon = _getIcon(this._extension, isEnabled ? 'mosaic-on-symbolic' : 'mosaic-off-symbolic');
         }
-    
+
         destroy() {
             if (this._wsSwitchedId) {
                 this._workspaceManager.disconnect(this._wsSwitchedId);
                 this._wsSwitchedId = null;
             }
-        
+
             this.quickSettingsItems.forEach(item => item.destroy());
             super.destroy();
         }

--- a/extension/reordering.js
+++ b/extension/reordering.js
@@ -191,9 +191,11 @@ export const ReorderingManager = GObject.registerClass({
         const workspace = meta_window.get_workspace();
         this.dragStart = false;
 
-        // Persist chosen layout order
+        // Persist chosen layout order and shape. Use the shape the layout was built from,
+        // not one re-derived from positions, since a row of unequal-height windows has
+        // differing top edges and would be misread as separate rows.
         if (!skip_apply && this._chosenLayout && this._tilingManager) {
-            this._tilingManager.applyOrderOp(workspace, this._chosenLayout.permOrder);
+            this._tilingManager.pinComposition(workspace, this._chosenLayout.shape, this._chosenLayout.permOrder);
         }
 
         this._dragLayouts = null;

--- a/extension/resizeHandler.js
+++ b/extension/resizeHandler.js
@@ -295,7 +295,7 @@ export const ResizeHandler = GObject.registerClass({
             if (pendingSmartSize) {
                 if (rect.width > pendingSmartSize.width + 2 || rect.height > pendingSmartSize.height + 2) {
                     if (this._shouldRetryClamp(window, pendingSmartSize)) {
-                        Logger.log(`[SMART RESIZE] Window ${window.get_id()} clamped while still settling: target=${pendingSmartSize.width}×${pendingSmartSize.height}, actual=${rect.width}×${rect.height} - retrying once`);
+                        Logger.log(`[SMART RESIZE] Window ${window.get_id()} clamped while still settling: target=${pendingSmartSize.width}×${pendingSmartSize.height}, actual=${rect.width}×${rect.height}; retrying once`);
                         WindowState.set(window, 'clampRetryTarget', { width: pendingSmartSize.width, height: pendingSmartSize.height });
                         const retryRect = window.get_frame_rect();
                         this._timeoutRegistry.add(constants.RESIZE_CLAMP_RETRY_DELAY_MS, () => {
@@ -303,7 +303,7 @@ export const ResizeHandler = GObject.registerClass({
                                 Logger.log(`[SMART RESIZE] Window ${window.get_id()} clamp retry firing: requesting ${pendingSmartSize.width}×${pendingSmartSize.height}`);
                                 window.move_resize_frame(false, retryRect.x, retryRect.y, pendingSmartSize.width, pendingSmartSize.height);
                             } else {
-                                Logger.log(`[SMART RESIZE] Window ${window.get_id()} clamp retry skipped - window gone`);
+                                Logger.log(`[SMART RESIZE] Window ${window.get_id()} clamp retry skipped; window gone`);
                             }
                             return GLib.SOURCE_REMOVE;
                         }, 'resizeHandler_clampRetry');
@@ -311,10 +311,34 @@ export const ResizeHandler = GObject.registerClass({
                         return;
                     }
 
-                    Logger.log(`[SMART RESIZE] Window ${window.get_id()} clamped: target=${pendingSmartSize.width}×${pendingSmartSize.height}, actual=${rect.width}×${rect.height}`);
+                    // Only a dimension that shrank below its opening size but stopped above
+                    // target really clamped; one still at its opening size just never applied
+                    // the resize, and freezing that as a minimum is the fake floor to avoid.
+                    const originalSize = WindowState.get(window, 'originalSize')
+                        || WindowState.get(window, 'preferredSize')
+                        || WindowState.get(window, 'openingSize');
+                    const shrank = constants.SMART_RESIZE_CLAMP_MIN_SHRINK_PX;
+                    const clampedW = !!originalSize
+                        && rect.width > pendingSmartSize.width + 2
+                        && rect.width < originalSize.width - shrank;
+                    const clampedH = !!originalSize
+                        && rect.height > pendingSmartSize.height + 2
+                        && rect.height < originalSize.height - shrank;
+
+                    if (!clampedW && !clampedH) {
+                        Logger.log(`[SMART RESIZE] Window ${window.get_id()} at pre-resize size ${rect.width}×${rect.height} (orig ${originalSize?.width}×${originalSize?.height}); not a real clamp, dropping target`);
+                        WindowState.set(window, 'targetSmartResizeSize', null);
+                        WindowState.remove(window, 'clampRetryTarget');
+                        this._sizeChanged = false;
+                        return;
+                    }
+
+                    Logger.log(`[SMART RESIZE] Window ${window.get_id()} clamped: target=${pendingSmartSize.width}×${pendingSmartSize.height}, actual=${rect.width}×${rect.height}, orig=${originalSize?.width}×${originalSize?.height}`);
                     WindowState.set(window, 'targetSmartResizeSize', { width: rect.width, height: rect.height });
-                    WindowState.set(window, 'actualMinWidth', rect.width);
-                    WindowState.set(window, 'actualMinHeight', rect.height);
+                    // Only the dimension that genuinely clamped is a real minimum; the other
+                    // might still be mid-flight.
+                    if (clampedW) WindowState.set(window, 'actualMinWidth', rect.width);
+                    if (clampedH) WindowState.set(window, 'actualMinHeight', rect.height);
                     WindowState.remove(window, 'clampRetryTarget');
 
                     // A window we just placed can clamp a few px against its own minimum.
@@ -324,7 +348,7 @@ export const ResizeHandler = GObject.registerClass({
                     if (!this._resizeGracePeriod || (now - this._resizeGracePeriod) >= constants.REVERSE_RESIZE_PROTECTION_MS) {
                         this._queueConstraintRebalance(window);
                     } else {
-                        Logger.log(`[SMART RESIZE] Window ${window.get_id()} clamp rebalance skipped - within grace period`);
+                        Logger.log(`[SMART RESIZE] Window ${window.get_id()} clamp rebalance skipped; within grace period`);
                     }
                 } else {
                     WindowState.set(window, 'targetSmartResizeSize', null);

--- a/extension/resizeHandler.js
+++ b/extension/resizeHandler.js
@@ -20,7 +20,7 @@ export const ResizeHandler = GObject.registerClass({
     _init(extension) {
         super._init();
         this._ext = extension;
-        
+
         // Resize state
         this._sizeChanged = false;
         this._resizeOverflowWindow = null;
@@ -90,14 +90,14 @@ export const ResizeHandler = GObject.registerClass({
         this._resizeInOverflow = false;
         this._lastResizeTileTime = 0;
         this.animationsManager.setResizingWindow(window.get_id());
-        
+
         // Always clear smart-resize target so manual resize takes precedence
         WindowState.set(window, 'targetSmartResizeSize', null);
         if (WindowState.get(window, 'isSmartResizing')) {
             Logger.log(`Manual resize started for ${window.get_id()} - clearing smart-resize state`);
             WindowState.set(window, 'isSmartResizing', false);
         }
-        
+
         Logger.log(`Tracking resize for window ${window.get_id()}, grabpo=${grabpo}`);
     }
 
@@ -364,15 +364,15 @@ export const ResizeHandler = GObject.registerClass({
                 this._sizeChanged = false;
                 return;
             }
-            
+
             if (WindowState.get(window, 'actualMinWidth') && rect.width > WindowState.get(window, 'actualMinWidth') + 20) {
                 WindowState.remove(window, 'actualMinWidth');
                 WindowState.remove(window, 'actualMinHeight');
             }
-            
+
             const isConstrained = WindowState.get(window, 'isConstrainedByMosaic');
             const isManualResizeAction = this._currentGrabOp && isResizeGrabOp(this._currentGrabOp);
-            
+
             // If constrained but dimensions differ significantly from Smart Resize target,
             // assume an external or ambient resize and lift the constraint.
             let userForcedResize = isManualResizeAction;
@@ -387,7 +387,7 @@ export const ResizeHandler = GObject.registerClass({
                     }
                 }
             }
-            
+
             // Mirrors savePreferredSize's guard: a born-maximized window mid-unmaximize can
             // report its still-fullscreen frame here before tiling shrinks it, baking it in
             // as preferredSize and making the window read as workspace-filling forever.
@@ -432,10 +432,10 @@ export const ResizeHandler = GObject.registerClass({
                     }
                 }
             }
-            
+
             // Mode-Based Lock Cleanup
             WindowState.remove(window, 'isEnteringSacred');
-            
+
             if (this._skipNextTiling === window.get_id()) return;
 
             const tileState = this.edgeTilingManager.getWindowState(window);
@@ -445,21 +445,21 @@ export const ResizeHandler = GObject.registerClass({
             this._sizeChanged = true;
             const workspace = window.get_workspace();
             const monitor = window.get_monitor();
-            
+
             if (WindowState.get(window, 'movedByOverflow')) {
                 this._sizeChanged = false;
                 return;
             }
-            
+
             if (!this.windowingManager.isMaximizedOrFullscreen(window)) {
                 const isManualResize = this._currentGrabOp && isResizeGrabOp(this._currentGrabOp);
                 const windowId = window.get_id();
                 const resizeNow = GLib.get_monotonic_time() / 1000;
-                const isActiveResize = isManualResize || 
+                const isActiveResize = isManualResize ||
                     (this._lastResizeWindow === windowId && (resizeNow - this._lastResizeTime) < constants.RESIZE_SETTLE_DELAY_MS * 2);
                 this._lastResizeWindow = windowId;
                 this._lastResizeTime = resizeNow;
-                
+
                 if (isActiveResize) {
                     // Throttle: execute immediately, skip if too soon since last retile
                     if (this._lastResizeTileTime && (resizeNow - this._lastResizeTileTime) < 16) {
@@ -520,14 +520,14 @@ export const ResizeHandler = GObject.registerClass({
                     this._sizeChanged = false;
                     return;
                 }
-                
+
                 const canFit = this.tilingManager.canFitWindow(window, workspace, monitor);
                 const now = GLib.get_monotonic_time() / 1000;
                 if (this._resizeGracePeriod && (now - this._resizeGracePeriod) < constants.REVERSE_RESIZE_PROTECTION_MS) {
                     this._sizeChanged = false;
                     return;
                 }
-                
+
                 if (WindowState.get(window, 'isSmartResizing') || this.tilingManager._isSmartResizingBlocked) {
                     this._sizeChanged = false;
                     return;
@@ -556,7 +556,7 @@ export const ResizeHandler = GObject.registerClass({
                             this._sizeChanged = false;
                             return;
                         }
-                        
+
                         if (this._ext.windowHandler && this._ext.windowHandler.isWorkspaceLocked(workspace)) {
                             this._sizeChanged = false;
                             return;
@@ -576,18 +576,18 @@ export const ResizeHandler = GObject.registerClass({
                 } else if (canFit && this._resizeOverflowWindow === window) {
                     this._resizeOverflowWindow = null;
                 }
-                
+
                 // If it fits, perform tiling to ensure other windows move out of the way (live tiling)
                 // However, we throttle it slightly to avoid excessive calculations during smooth resizing
                 if (canFit) {
                     if (this._lastTileTime && (now - this._lastTileTime < 30)) {
                         this._sizeChanged = false;
-                        return; 
+                        return;
                     }
                     this._lastTileTime = now;
                 }
             }
-            
+
             this.tilingManager.tileWorkspaceWindows(workspace, null, monitor, true);
             this._sizeChanged = false;
         }
@@ -689,16 +689,16 @@ export const ResizeHandler = GObject.registerClass({
         const currentWorkspace = window.get_workspace();
         const workspaceManager = global.workspace_manager;
         const windowId = window.get_id();
-        
+
         if (preMaxSize) {
             WindowState.set(window, 'openingSize', preMaxSize);
         }
-        
+
         if (origIndex >= workspaceManager.get_n_workspaces()) {
             this.tilingManager.tileWorkspaceWindows(currentWorkspace, window, monitor);
             return;
         }
-        
+
         const targetWorkspace = workspaceManager.get_workspace_by_index(origIndex);
         if (currentWorkspace.index() === origIndex) {
             Logger.log(`handleUnmaximizeUndo: Window ${windowId} unmaximized on SAME workspace - tiling immediately`);
@@ -706,9 +706,9 @@ export const ResizeHandler = GObject.registerClass({
             if (preMaxSize) {
                 WindowState.set(window, 'targetRestoredSize', preMaxSize);
             }
-            
+
             this.tilingManager.tileWorkspaceWindows(currentWorkspace, window, monitor, true);
-            
+
             this._timeoutRegistry.add(constants.RESIZE_SETTLE_DELAY_MS + 100, () => {
                 WindowState.remove(window, 'unmaximizing');
                 WindowState.remove(window, 'targetRestoredSize');
@@ -716,11 +716,11 @@ export const ResizeHandler = GObject.registerClass({
             }, 'resizeHandler_settleUnmaximizeSame');
             return;
         }
-        
+
         if (preMaxSize) {
             WindowState.set(window, 'preferredSize', preMaxSize);
         }
-        
+
         // SMART FIT: Try to fit without resize first, then attempt to fit WITH resize
         const existingWindows = targetWorkspace.list_windows().filter(w => !this.windowingManager.isExcluded(w));
         let canFit = this.tilingManager.canFitWindow(window, targetWorkspace, monitor, true, preMaxSize);
@@ -740,17 +740,17 @@ export const ResizeHandler = GObject.registerClass({
                 this.tilingManager._pendingMiniatureWindows = pendingMiniatures;
             }
         }
-        
+
         if (!canFit) {
             Logger.log(`[SACRED-STAY] handleUnmaximizeUndo: Window ${windowId} unable to fit even with Smart Resize - staying in current workspace`);
             this.tilingManager.tileWorkspaceWindows(currentWorkspace, window, monitor);
             return;
         }
-        
+
         if (resizeNeeded) {
             Logger.log(`handleUnmaximizeUndo: Smart Resize applied successfully for return of ${windowId}`);
         }
-        
+
         window.unmaximize();
         WindowState.set(window, 'unmaximizing', true);
         WindowState.set(window, 'isConstrainedByMosaic', true);

--- a/extension/resizeHandler.js
+++ b/extension/resizeHandler.js
@@ -167,11 +167,9 @@ export const ResizeHandler = GObject.registerClass({
         }
     };
 
-    // Isolates a maximized/fullscreen window to its own workspace, after a short
-    // debounce so a quick toggle back never even starts the move. Some apps'
-    // fullscreen doesn't reliably trigger window_manager's size-change signal, so
-    // this is also called from windowHandler's notify::fullscreen as a backup -
-    // the pending flag below makes calling it twice for the same transition safe.
+    // Debounced so a quick toggle back never even starts the displace. Also called
+    // from windowHandler's notify::fullscreen as a backup (some apps' fullscreen
+    // doesn't reliably fire size-change); sacredEnterPending makes duplicate calls safe.
     tryEnterSacred(window) {
         // Detect born-maximized: size-change fires BEFORE window-created for new windows.
         // A window with no preferredSize/openingSize hasn't been through onWindowCreated yet.
@@ -205,7 +203,7 @@ export const ResizeHandler = GObject.registerClass({
             return;
         }
 
-        Logger.log('[SACRED-ENTER] User entering sacred state - debouncing before moving to new workspace');
+        Logger.log('[SACRED-ENTER] User entering sacred state - debouncing before displacing other windows');
         WindowState.set(window, 'sacredEnterPending', true);
         const preMaxSize = WindowState.get(window, 'preferredSize') || WindowState.get(window, 'openingSize');
 
@@ -224,20 +222,50 @@ export const ResizeHandler = GObject.registerClass({
                 return GLib.SOURCE_REMOVE;
             }
 
-            Logger.log('[SACRED-ENTER] Still in sacred state after debounce - moving to new workspace');
+            Logger.log('[SACRED-ENTER] Still in sacred state after debounce - displacing other windows');
+
+            const preInsertionIndex = currentWorkspace.index();
+            const targetWorkspace = this.windowingManager.createOrReuseLeftWorkspace(currentWorkspace);
+
+            // Capture original workspace index AFTER workspace insertion, since
+            // createOrReuseLeftWorkspace may reorder and shift the current workspace.
             const originalWorkspaceIndex = currentWorkspace.index();
 
-            this.windowingManager.moveOversizedWindow(window).then((newWorkspace) => {
-                if (newWorkspace) {
-                    WindowState.set(window, 'maximizedUndoInfo', {
-                        originalWorkspace: originalWorkspaceIndex,
-                        currentWorkspace: newWorkspace.index(),
-                        monitor: currentMonitor,
-                        preMaxSize: preMaxSize
-                    });
-                    this.tilingManager.tileWorkspaceWindows(currentWorkspace, null, currentMonitor, false);
+            // Keep the maximized window in place so expand doesn't fight a lateral slide.
+            const otherWindows = this.windowingManager.getMonitorWorkspaceWindows(currentWorkspace, currentMonitor)
+                .filter(w => w !== window && !this.windowingManager.isExcluded(w));
+
+            if (otherWindows.length === 0) {
+                Logger.log(`[SACRED-ENTER] Window ${window.get_id()} has no other windows to displace`);
+                return GLib.SOURCE_REMOVE;
+            }
+
+            for (const w of otherWindows) {
+                WindowState.set(w, 'movedByOverflow', true);
+                w.change_workspace(targetWorkspace);
+            }
+
+            WindowState.set(window, 'maximizedUndoInfo', {
+                originalWorkspace: originalWorkspaceIndex,
+                displacedWorkspace: targetWorkspace.index(),
+                monitor: currentMonitor,
+                preMaxSize: preMaxSize,
+                osdWorkspace: preInsertionIndex
+            });
+
+            this.tilingManager.tileWorkspaceWindows(targetWorkspace, null, currentMonitor);
+
+            // OSD on the current workspace
+            this.windowingManager.showWorkspaceSwitcher(currentWorkspace, currentMonitor);
+
+            // Clear overflow flags after a settling delay
+            this._timeoutRegistry.add(constants.RESIZE_SETTLE_DELAY_MS, () => {
+                for (const w of otherWindows) {
+                    WindowState.remove(w, 'movedByOverflow');
                 }
-            }).catch(e => Logger.error(`Sacred isolation failed: ${e}`));
+                return GLib.SOURCE_REMOVE;
+            }, 'resizeHandler_sacredDisplaceSettle');
+
             return GLib.SOURCE_REMOVE;
         }, 'resizeHandler_sacredEnterDebounce');
     }
@@ -627,50 +655,41 @@ export const ResizeHandler = GObject.registerClass({
     completeSacredReturn(window, originWorkspaceIndex) {
         if (WindowState.get(window, 'isRestoringSacred') !== originWorkspaceIndex) return;
 
-        Logger.log(`[SACRED-MOVE] Window ${window.get_id()} finished in-place resize. Moving to origin workspace ${originWorkspaceIndex}.`);
+        Logger.log(`[SACRED-RETURN] Window ${window.get_id()} finished unmaximize. Tiling on WS ${originWorkspaceIndex}.`);
 
         const workspaceManager = global.workspace_manager;
         if (originWorkspaceIndex < 0 || originWorkspaceIndex >= workspaceManager.get_n_workspaces()) {
             WindowState.remove(window, 'isRestoringSacred');
-            WindowState.remove(window, 'sacredFitConfirmed');
-            WindowState.remove(window, 'pendingMiniaturesForReturn');
+            WindowState.remove(window, 'sacredDisplacedWorkspace');
             return;
         }
 
         const originWS = workspaceManager.get_workspace_by_index(originWorkspaceIndex);
         const monitor = window.get_monitor();
-        const oldWorkspace = window.get_workspace();
-        // handleUnmaximizeUndo sets this once it already checked the window
-        // fits, so the tile pass below doesn't second-guess it as overflow.
-        const fitConfirmed = WindowState.get(window, 'sacredFitConfirmed') === true;
-        const pendingMiniatures = WindowState.get(window, 'pendingMiniaturesForReturn') || [];
-
-        // MOVE ATOMICALLY
-        window.change_workspace(originWS);
-        originWS.activate(global.get_current_time());
-        this.windowingManager.showWorkspaceSwitcher(originWS, monitor);
+        const displacedIndex = WindowState.get(window, 'sacredDisplacedWorkspace');
 
         // CLEAR FLAGS IMMEDIATELY to prevent double-move
         WindowState.remove(window, 'isRestoringSacred');
-        WindowState.remove(window, 'sacredFitConfirmed');
-        WindowState.remove(window, 'pendingMiniaturesForReturn');
+        WindowState.remove(window, 'sacredDisplacedWorkspace');
 
-        // TILE IN DESTINATION
         afterWorkspaceSwitch(() => {
-            Logger.log(`Triggering tiling in destination workspace ${originWorkspaceIndex}`);
+            Logger.log(`Triggering tiling in workspace ${originWorkspaceIndex}`);
+
             this.tilingManager._isSmartResizingBlocked = true;
             try {
-                this.tilingManager._pendingMiniatureWindows = pendingMiniatures;
-                this.tilingManager.tileWorkspaceWindows(originWS, window, monitor, fitConfirmed);
+                this.tilingManager.tileWorkspaceWindows(originWS, window, monitor, true);
             } finally {
                 this.tilingManager._isSmartResizingBlocked = false;
             }
-            if (isWorkspaceAlive(oldWorkspace, workspaceManager)) {
-                this.tilingManager.tileWorkspaceWindows(oldWorkspace, null, monitor, true);
+
+            // Tile displaced workspace if it still has windows
+            if (displacedIndex !== undefined && displacedIndex >= 0 && displacedIndex < workspaceManager.get_n_workspaces()) {
+                const displacedWS = workspaceManager.get_workspace_by_index(displacedIndex);
+                if (displacedWS && isWorkspaceAlive(displacedWS, workspaceManager)) {
+                    this.tilingManager.tileWorkspaceWindows(displacedWS, null, monitor, true);
+                }
             }
 
-            // Same clamp protection as above, so this window doesn't get
-            // rebalanced right after it just landed.
             this._resizeGracePeriod = GLib.get_monotonic_time() / 1000;
 
             // Clear unmaximizing flags after a settle period
@@ -685,91 +704,64 @@ export const ResizeHandler = GObject.registerClass({
     }
 
     async handleUnmaximizeUndo(window, maxInfo) {
-        const { originalWorkspace: origIndex, monitor, preMaxSize } = maxInfo;
-        const currentWorkspace = window.get_workspace();
+        const { originalWorkspace: origIndex, preMaxSize, displacedWorkspace, osdWorkspace } = maxInfo;
         const workspaceManager = global.workspace_manager;
         const windowId = window.get_id();
 
         if (preMaxSize) {
             WindowState.set(window, 'openingSize', preMaxSize);
-        }
-
-        if (origIndex >= workspaceManager.get_n_workspaces()) {
-            this.tilingManager.tileWorkspaceWindows(currentWorkspace, window, monitor);
-            return;
-        }
-
-        const targetWorkspace = workspaceManager.get_workspace_by_index(origIndex);
-        if (currentWorkspace.index() === origIndex) {
-            Logger.log(`handleUnmaximizeUndo: Window ${windowId} unmaximized on SAME workspace - tiling immediately`);
-            WindowState.set(window, 'unmaximizing', true);
-            if (preMaxSize) {
-                WindowState.set(window, 'targetRestoredSize', preMaxSize);
-            }
-
-            this.tilingManager.tileWorkspaceWindows(currentWorkspace, window, monitor, true);
-
-            this._timeoutRegistry.add(constants.RESIZE_SETTLE_DELAY_MS + 100, () => {
-                WindowState.remove(window, 'unmaximizing');
-                WindowState.remove(window, 'targetRestoredSize');
-                return GLib.SOURCE_REMOVE;
-            }, 'resizeHandler_settleUnmaximizeSame');
-            return;
-        }
-
-        if (preMaxSize) {
             WindowState.set(window, 'preferredSize', preMaxSize);
+            WindowState.set(window, 'targetRestoredSize', preMaxSize);
         }
 
-        // SMART FIT: Try to fit without resize first, then attempt to fit WITH resize
-        const existingWindows = targetWorkspace.list_windows().filter(w => !this.windowingManager.isExcluded(w));
-        let canFit = this.tilingManager.canFitWindow(window, targetWorkspace, monitor, true, preMaxSize);
-        let resizeNeeded = false;
-        let pendingMiniatures = [];
+        // completeSacredReturn reads this to tile the displaced workspace
+        if (displacedWorkspace !== undefined) {
+            WindowState.set(window, 'sacredDisplacedWorkspace', displacedWorkspace);
+        }
 
-        if (!canFit) {
-            Logger.log(`handleUnmaximizeUndo: Window ${windowId} doesn't fit normally - attempting Smart Resize fit`);
-            // Pass window as focused override: preMaxSize is its ceiling, so it won't be miniaturized.
-            const fitResult = this.tilingManager.tryFitWithResize(window, existingWindows, this.tilingManager.getUsableWorkArea(targetWorkspace, monitor), window);
-            canFit = fitResult?.success ?? false;
-            resizeNeeded = canFit;
-            // Pending minis MUST reach the tile pass, since skipping leaves siblings at miniature size with no real miniature.
-            if (canFit) {
-                pendingMiniatures = fitResult.pendingWindows ?? [];
-                // Set early: intermediate tile calls treat these as pending-mini; afterWorkspaceSwitch re-sets before final pass.
-                this.tilingManager._pendingMiniatureWindows = pendingMiniatures;
+        // Move displaced windows back BEFORE unmaximizing so they're visible
+        // during the shrink animation instead of popping in afterward.
+        if (displacedWorkspace !== undefined && displacedWorkspace >= 0 && displacedWorkspace < workspaceManager.get_n_workspaces()) {
+            const displacedWS = workspaceManager.get_workspace_by_index(displacedWorkspace);
+            if (displacedWS && isWorkspaceAlive(displacedWS, workspaceManager)) {
+                const displacedWindows = displacedWS.list_windows()
+                    .filter(w => !this.windowingManager.isExcluded(w));
+                const targetWS = (origIndex >= 0 && origIndex < workspaceManager.get_n_workspaces())
+                    ? workspaceManager.get_workspace_by_index(origIndex)
+                    : null;
+                if (!targetWS) {
+                    Logger.log(`[SACRED] Origin workspace ${origIndex} no longer exists, moving displaced windows to current`);
+                }
+                for (const w of displacedWindows) {
+                    WindowState.set(w, 'movedByOverflow', true);
+                    w.change_workspace(targetWS || window.get_workspace());
+                }
+                // Clear overflow flags after a settling delay
+                this._timeoutRegistry.add(constants.RESIZE_SETTLE_DELAY_MS, () => {
+                    for (const w of displacedWindows) {
+                        WindowState.remove(w, 'movedByOverflow');
+                    }
+                    return GLib.SOURCE_REMOVE;
+                }, 'resizeHandler_sacredReturnSettle');
             }
         }
 
-        if (!canFit) {
-            Logger.log(`[SACRED-STAY] handleUnmaximizeUndo: Window ${windowId} unable to fit even with Smart Resize - staying in current workspace`);
-            this.tilingManager.tileWorkspaceWindows(currentWorkspace, window, monitor);
-            return;
-        }
-
-        if (resizeNeeded) {
-            Logger.log(`handleUnmaximizeUndo: Smart Resize applied successfully for return of ${windowId}`);
-        }
 
         window.unmaximize();
         WindowState.set(window, 'unmaximizing', true);
         WindowState.set(window, 'isConstrainedByMosaic', true);
 
-        if (preMaxSize) {
-            WindowState.set(window, 'targetRestoredSize', preMaxSize);
-            WindowState.set(window, 'openingSize', preMaxSize);
-            WindowState.set(window, 'preferredSize', preMaxSize);
+        // Show workspace OSD at the same visual position as when maximized
+        const osdWS = osdWorkspace !== undefined
+            ? global.workspace_manager.get_workspace_by_index(osdWorkspace)
+            : window.get_workspace();
+        if (osdWS) {
+            this.windowingManager.showWorkspaceSwitcher(osdWS, window.get_monitor());
         }
 
-        // Wait for the real size-changed confirmation instead of guessing with
-        // a timer - a fixed delay could move the window before it's actually
-        // done resizing, and it'd show up at the destination still huge.
+        // Stage 2 (completeSacredReturn) handles final tiling of all windows.
         WindowState.set(window, 'isRestoringSacred', origIndex);
-        WindowState.set(window, 'sacredFitConfirmed', true);
-        if (pendingMiniatures.length > 0) {
-            WindowState.set(window, 'pendingMiniaturesForReturn', pendingMiniatures);
-        }
         this.scheduleSacredRestoreSafety(window, origIndex);
-        Logger.log(`[SACRED-DEFER] Window ${windowId} resizing in place before deferred move to WS ${origIndex}`);
+        Logger.log(`[SACRED-DEFER] Window ${windowId} unmaximizing in place; displaced windows already returned`);
     }
 } );

--- a/extension/resizeHandler.js
+++ b/extension/resizeHandler.js
@@ -311,34 +311,15 @@ export const ResizeHandler = GObject.registerClass({
                         return;
                     }
 
-                    // Only a dimension that shrank below its opening size but stopped above
-                    // target really clamped; one still at its opening size just never applied
-                    // the resize, and freezing that as a minimum is the fake floor to avoid.
-                    const originalSize = WindowState.get(window, 'originalSize')
-                        || WindowState.get(window, 'preferredSize')
-                        || WindowState.get(window, 'openingSize');
-                    const shrank = constants.SMART_RESIZE_CLAMP_MIN_SHRINK_PX;
-                    const clampedW = !!originalSize
-                        && rect.width > pendingSmartSize.width + 2
-                        && rect.width < originalSize.width - shrank;
-                    const clampedH = !!originalSize
-                        && rect.height > pendingSmartSize.height + 2
-                        && rect.height < originalSize.height - shrank;
-
-                    if (!clampedW && !clampedH) {
-                        Logger.log(`[SMART RESIZE] Window ${window.get_id()} at pre-resize size ${rect.width}×${rect.height} (orig ${originalSize?.width}×${originalSize?.height}); not a real clamp, dropping target`);
-                        WindowState.set(window, 'targetSmartResizeSize', null);
-                        WindowState.remove(window, 'clampRetryTarget');
-                        this._sizeChanged = false;
-                        return;
-                    }
-
-                    Logger.log(`[SMART RESIZE] Window ${window.get_id()} clamped: target=${pendingSmartSize.width}×${pendingSmartSize.height}, actual=${rect.width}×${rect.height}, orig=${originalSize?.width}×${originalSize?.height}`);
+                    // The retry (or the settle window for older ones) already gave the async
+                    // resize its chance, so a frame still above target now is a genuine client
+                    // minimum, not lag. Trust it instead of guessing from how far it shrank.
+                    Logger.log(`[SMART RESIZE] Window ${window.get_id()} clamped: target=${pendingSmartSize.width}×${pendingSmartSize.height}, actual=${rect.width}×${rect.height}`);
                     WindowState.set(window, 'targetSmartResizeSize', { width: rect.width, height: rect.height });
-                    // Only the dimension that genuinely clamped is a real minimum; the other
-                    // might still be mid-flight.
-                    if (clampedW) WindowState.set(window, 'actualMinWidth', rect.width);
-                    if (clampedH) WindowState.set(window, 'actualMinHeight', rect.height);
+                    // Only the axis that stayed above target really clamped; the other reached
+                    // target and shouldn't be pinned as a minimum.
+                    if (rect.width > pendingSmartSize.width + 2) WindowState.set(window, 'actualMinWidth', rect.width);
+                    if (rect.height > pendingSmartSize.height + 2) WindowState.set(window, 'actualMinHeight', rect.height);
                     WindowState.remove(window, 'clampRetryTarget');
 
                     // A window we just placed can clamp a few px against its own minimum.

--- a/extension/settingsOverrider.js
+++ b/extension/settingsOverrider.js
@@ -11,7 +11,7 @@ export class SettingsOverrider {
     constructor() {
         this.#overrides = new Map();
     }
-    
+
     add(settings, key, value) {
         const schemaId = settings.schema_id;
 
@@ -36,7 +36,7 @@ export class SettingsOverrider {
         settings.set_value(key, value);
         Logger.log(`Overriding ${schemaId}.${key}`);
     }
-    
+
     clear() {
         if (!this.#overrides) return;
 
@@ -63,7 +63,7 @@ export class SettingsOverrider {
 
         this.#overrides.clear();
     }
-    
+
     destroy() {
         this.clear();
         this.#overrides = null;

--- a/extension/swapping.js
+++ b/extension/swapping.js
@@ -17,7 +17,7 @@ export const SwappingManager = GObject.registerClass({
         this._tilingManager = null;
         this._edgeTilingManager = null;
     }
-    
+
 
     setTilingManager(manager) {
         this._tilingManager = manager;
@@ -29,12 +29,12 @@ export const SwappingManager = GObject.registerClass({
 
     findNeighbor(window, direction, workspace, monitor) {
         if (!this._edgeTilingManager) return null;
-        
+
         const windowState = this._edgeTilingManager.getWindowState(window);
         const isWindowTiled = windowState && windowState.zone !== TileZone.NONE;
-        
+
         Logger.log(`Finding neighbor for window ${window.get_id()} in direction: ${direction}`);
-        
+
         if (isWindowTiled) {
             return this._findNeighborFromTiling(window, windowState.zone, direction, workspace, monitor);
         } else {
@@ -44,7 +44,7 @@ export const SwappingManager = GObject.registerClass({
 
     _findNeighborFromTiling(window, zone, direction, workspace, monitor) {
         const isQuarter = this._edgeTilingManager.isQuarterZone(zone);
-        
+
         if (direction === 'up' || direction === 'down') {
             if (!isQuarter) {
                 Logger.log('Vertical swap only works for quarter tiles');
@@ -57,40 +57,40 @@ export const SwappingManager = GObject.registerClass({
 
     _findVerticalQuarterNeighbor(zone, _direction, workspace, monitor) {
         const edgeTiledWindows = this._edgeTilingManager.getEdgeTiledWindows(workspace, monitor);
-        
+
         const verticalPairs = {
             [TileZone.TOP_LEFT]: TileZone.BOTTOM_LEFT,
             [TileZone.BOTTOM_LEFT]: TileZone.TOP_LEFT,
             [TileZone.TOP_RIGHT]: TileZone.BOTTOM_RIGHT,
             [TileZone.BOTTOM_RIGHT]: TileZone.TOP_RIGHT,
         };
-        
+
         const targetZone = verticalPairs[zone];
         if (!targetZone) return null;
-        
+
         const targetWindow = edgeTiledWindows.find(w => {
             const state = this._edgeTilingManager.getWindowState(w.window);
             return state && state.zone === targetZone;
         });
-        
+
         if (targetWindow) {
             return { window: targetWindow.window, zone: targetZone, type: 'tiling' };
         }
-        
+
         return { window: null, zone: targetZone, type: 'empty_tiling' };
     }
 
     _findHorizontalNeighborFromTiling(window, zone, direction, workspace, monitor) {
         const isLeft = zone === TileZone.LEFT_FULL || zone === TileZone.TOP_LEFT || zone === TileZone.BOTTOM_LEFT;
         const isRight = zone === TileZone.RIGHT_FULL || zone === TileZone.TOP_RIGHT || zone === TileZone.BOTTOM_RIGHT;
-        
+
         let targetSide;
         if (direction === 'left') targetSide = 'left';
         else if (direction === 'right') targetSide = 'right';
         else return null;
-        
+
         const movingToOppositeSide = (isLeft && targetSide === 'right') || (isRight && targetSide === 'left');
-        
+
         if (movingToOppositeSide) {
             return this._findOppositeSideNeighbor(window, zone, targetSide, workspace, monitor);
         } else {
@@ -101,10 +101,10 @@ export const SwappingManager = GObject.registerClass({
     _findOppositeSideNeighbor(_window, sourceZone, targetSide, workspace, monitor) {
         const edgeTiledWindows = this._edgeTilingManager.getEdgeTiledWindows(workspace, monitor);
         const isQuarter = this._edgeTilingManager.isQuarterZone(sourceZone);
-        
+
         const isTop = sourceZone === TileZone.TOP_LEFT || sourceZone === TileZone.TOP_RIGHT;
         const isBottom = sourceZone === TileZone.BOTTOM_LEFT || sourceZone === TileZone.BOTTOM_RIGHT;
-        
+
         const targetSideWindows = edgeTiledWindows.filter(w => {
             const state = this._edgeTilingManager.getWindowState(w.window);
             if (!state) return false;
@@ -115,11 +115,11 @@ export const SwappingManager = GObject.registerClass({
                 return z === TileZone.RIGHT_FULL || z === TileZone.TOP_RIGHT || z === TileZone.BOTTOM_RIGHT;
             }
         });
-        
+
         if (targetSideWindows.length === 0) {
             const mosaicNeighbor = this._findMosaicOnSide(targetSide, workspace, monitor);
             if (mosaicNeighbor) return mosaicNeighbor;
-            
+
             if (isQuarter) {
                 const targetZone = targetSide === 'left' ? TileZone.LEFT_FULL : TileZone.RIGHT_FULL;
                 return { window: null, zone: targetZone, type: 'empty_tiling_expand' };
@@ -127,7 +127,7 @@ export const SwappingManager = GObject.registerClass({
                 return null;
             }
         }
-        
+
         if (isQuarter) {
             const matchingLevel = targetSideWindows.find(w => {
                 const state = this._edgeTilingManager.getWindowState(w.window);
@@ -138,12 +138,12 @@ export const SwappingManager = GObject.registerClass({
                 }
                 return false;
             });
-            
+
             if (matchingLevel) {
                 const state = this._edgeTilingManager.getWindowState(matchingLevel.window);
                 return { window: matchingLevel.window, zone: state.zone, type: 'tiling' };
             }
-            
+
             const targetWindow = targetSideWindows[0];
             const state = this._edgeTilingManager.getWindowState(targetWindow.window);
             return { window: targetWindow.window, zone: state.zone, type: 'tiling' };
@@ -156,20 +156,20 @@ export const SwappingManager = GObject.registerClass({
 
     _findMosaicOnSide(side, workspace, monitor) {
         if (!this._edgeTilingManager) return null;
-        
+
         const mosaicWindows = this._edgeTilingManager.getNonEdgeTiledWindows(workspace, monitor);
         if (mosaicWindows.length === 0) return null;
-        
+
         const workArea = workspace.get_work_area_for_monitor(monitor);
         const centerX = workArea.x + workArea.width / 2;
-        
+
         const sideWindows = mosaicWindows.filter(w => {
             const frame = w.get_frame_rect();
             const windowCenterX = frame.x + frame.width / 2;
             if (side === 'left') return windowCenterX < centerX;
             else return windowCenterX >= centerX;
         });
-        
+
         if (sideWindows.length > 0) {
             return { window: sideWindows[0], zone: null, type: 'mosaic' };
         }
@@ -182,19 +182,19 @@ export const SwappingManager = GObject.registerClass({
 
     _findNeighborFromMosaic(window, direction, workspace, monitor) {
         if (!this._edgeTilingManager) return null;
-        
+
         const mosaicWindows = this._edgeTilingManager.getNonEdgeTiledWindows(workspace, monitor);
         const windowFrame = window.get_frame_rect();
-        
+
         const mosaicNeighbor = this._findClosestMosaicInDirection(window, mosaicWindows, direction);
         if (mosaicNeighbor) return mosaicNeighbor;
-        
+
         if (direction === 'left' || direction === 'right') {
             const edgeTiledWindows = this._edgeTilingManager.getEdgeTiledWindows(workspace, monitor);
             const workArea = workspace.get_work_area_for_monitor(monitor);
             const centerX = workArea.x + workArea.width / 2;
             const windowCenterX = windowFrame.x + windowFrame.width / 2;
-            
+
             if (direction === 'left' && windowCenterX > centerX) {
                 const leftTiles = edgeTiledWindows.filter(w => {
                     const state = this._edgeTilingManager.getWindowState(w.window);
@@ -222,14 +222,14 @@ export const SwappingManager = GObject.registerClass({
         const windowFrame = window.get_frame_rect();
         const windowCenterX = windowFrame.x + windowFrame.width / 2;
         const windowCenterY = windowFrame.y + windowFrame.height / 2;
-        
+
         const candidates = mosaicWindows.filter(w => {
             if (w.get_id() === window.get_id()) return false;
-            
+
             const frame = w.get_frame_rect();
             const centerX = frame.x + frame.width / 2;
             const centerY = frame.y + frame.height / 2;
-            
+
             if (direction === 'left' || direction === 'right') {
                 const verticalOverlap = !(windowFrame.y + windowFrame.height <= frame.y || frame.y + frame.height <= windowFrame.y);
                 if (!verticalOverlap) return false;
@@ -238,7 +238,7 @@ export const SwappingManager = GObject.registerClass({
                 const horizontalOverlap = !(windowFrame.x + windowFrame.width <= frame.x || frame.x + frame.width <= windowFrame.x);
                 if (!horizontalOverlap) return false;
             }
-            
+
             switch (direction) {
                 case 'left': return centerX < windowCenterX;
                 case 'right': return centerX > windowCenterX;
@@ -247,38 +247,38 @@ export const SwappingManager = GObject.registerClass({
                 default: return false;
             }
         });
-        
+
         if (candidates.length === 0) return null;
-        
+
         let closest = candidates[0];
         let minDistance = Infinity;
-        
+
         for (const candidate of candidates) {
             const frame = candidate.get_frame_rect();
             const centerX = frame.x + frame.width / 2;
             const centerY = frame.y + frame.height / 2;
             let distance = Infinity;
-            
+
             switch (direction) {
                 case 'left': distance = windowCenterX - centerX; break;
                 case 'right': distance = centerX - windowCenterX; break;
                 case 'up': distance = windowCenterY - centerY; break;
                 case 'down': distance = centerY - windowCenterY; break;
             }
-            
+
             if (distance < minDistance) {
                 minDistance = distance;
                 closest = candidate;
             }
         }
-        
+
         return { window: closest, zone: null, type: 'mosaic' };
     }
 
     swapWindow(window, direction) {
         const workspace = window.get_workspace();
         const monitor = window.get_monitor();
-        
+
         Logger.log(`Swapping window ${window.get_id()} in direction: ${direction}`);
 
         const windowState = this._edgeTilingManager.getWindowState(window);
@@ -353,14 +353,14 @@ export const SwappingManager = GObject.registerClass({
 
     swapWindows(draggedWindow, targetWindow, targetZone, workspace, monitor) {
         if (!this._edgeTilingManager) return false;
-        
+
         Logger.log(`DnD Swap: ${draggedWindow.get_id()} → zone ${targetZone}`);
-        
+
         if (draggedWindow.get_id() === targetWindow.get_id()) return false;
-        
+
         const draggedState = this._edgeTilingManager.getWindowState(draggedWindow);
         const isDraggedTiled = draggedState && draggedState.zone !== TileZone.NONE;
-        
+
         if (isDraggedTiled) {
             return this._swapTiledWindows(draggedWindow, draggedState.zone, targetWindow, targetZone, workspace, monitor);
         } else {
@@ -370,12 +370,12 @@ export const SwappingManager = GObject.registerClass({
 
     _swapMosaicWindows(window1, window2, workspace, monitor) {
         if (!this._tilingManager) return false;
-        
+
         Logger.log(`Swapping mosaic windows: ${window1.get_id()} ↔ ${window2.get_id()}`);
-        
+
         const id1 = window1.get_id();
         const id2 = window2.get_id();
-        
+
         this._tilingManager.setTmpSwap(id1, id2);
         this._tilingManager.applyTmpSwap(workspace);
         this._tilingManager.clearTmpSwap();
@@ -388,11 +388,11 @@ export const SwappingManager = GObject.registerClass({
 
     _swapMosaicWithTiled(mosaicWindow, tiledWindow, tiledZone, workspace, monitor) {
         if (!this._edgeTilingManager) return false;
-        
+
         Logger.log(`Swapping mosaic ${mosaicWindow.get_id()} with tiled ${tiledWindow.get_id()}`);
-        
+
         this._edgeTilingManager.removeTile(tiledWindow);
-        
+
         const workArea = workspace.get_work_area_for_monitor(monitor);
         this._edgeTilingManager.applyTile(mosaicWindow, tiledZone, workArea, true);
 
@@ -407,22 +407,22 @@ export const SwappingManager = GObject.registerClass({
 
     _swapTiledWindows(window1, zone1, window2, zone2, workspace, monitor) {
         if (!this._edgeTilingManager) return false;
-        
+
         Logger.log(`Swapping tiled windows: ${window1.get_id()} ↔ ${window2.get_id()}`);
-        
+
         const workArea = workspace.get_work_area_for_monitor(monitor);
         this._edgeTilingManager.applyTile(window1, zone2, workArea);
         this._edgeTilingManager.applyTile(window2, zone1, workArea);
-        
+
         WindowState.set(window1, 'lastSwapTime', GLib.get_monotonic_time() / 1000);
         WindowState.set(window2, 'lastSwapTime', GLib.get_monotonic_time() / 1000);
-        
+
         return true;
     }
 
     _tileToEmptyZone(window, zone, workspace, monitor) {
         if (!this._edgeTilingManager) return false;
-        
+
         Logger.log(`Tiling window ${window.get_id()} to empty zone ${zone}`);
         const workArea = workspace.get_work_area_for_monitor(monitor);
         this._edgeTilingManager.applyTile(window, zone, workArea);
@@ -432,7 +432,7 @@ export const SwappingManager = GObject.registerClass({
 
     _expandQuarterToFull(window, _currentZone, targetZone, workspace, monitor) {
         if (!this._edgeTilingManager) return false;
-        
+
         Logger.log(`Expanding quarter tile ${window.get_id()} to ${targetZone}`);
         const workArea = workspace.get_work_area_for_monitor(monitor);
         this._edgeTilingManager.applyTile(window, targetZone, workArea);

--- a/extension/swapping.js
+++ b/extension/swapping.js
@@ -281,23 +281,43 @@ export const SwappingManager = GObject.registerClass({
         
         Logger.log(`Swapping window ${window.get_id()} in direction: ${direction}`);
 
-        // Hysteresis: Prevent rapid swapping
+        const windowState = this._edgeTilingManager.getWindowState(window);
+        const isWindowTiled = windowState && windowState.zone !== TileZone.NONE;
+
+        const neighbor = this.findNeighbor(window, direction, workspace, monitor);
+
+        // A snapped (edge-tiled) neighbor in this direction wins, so only recompose the
+        // mosaic when there isn't one. Recomposition is deterministic per press and moves
+        // retarget mid-flight, so it skips the anti-oscillation throttle below.
+        const snappedInDirection = neighbor && neighbor.type === 'tiling';
+        if (!isWindowTiled && this._tilingManager && !snappedInDirection) {
+            const best = this._tilingManager.bestRecomposition(workspace, monitor, window, direction);
+            if (best) {
+                this._tilingManager.pinComposition(workspace, best.shape, best.order);
+                this._tilingManager.invalidateLayoutCache();
+                this._tilingManager.tileWorkspaceWindows(workspace, null, monitor, false);
+                Logger.log(`Recomposed to [${best.shape.join(',')}] moving ${window.get_id()} ${direction}`);
+                return true;
+            }
+            // Recompose is the whole mosaic keyboard action; if nothing moves that way, do
+            // nothing rather than an order-swap that would leave the pinned shape stale.
+            Logger.log(`No recomposition for ${window.get_id()} ${direction}`);
+            return false;
+        }
+
+        // Hysteresis: prevent rapid oscillation of the neighbor swap below.
         const lastSwap = WindowState.get(window, 'lastSwapTime');
         const now = GLib.get_monotonic_time() / 1000;
         if (lastSwap && (now - lastSwap) < 500) {
             Logger.log(`Swap throttled for window ${window.get_id()}`);
             return false;
         }
-        
-        const neighbor = this.findNeighbor(window, direction, workspace, monitor);
+
         if (!neighbor) {
             Logger.log('No neighbor found in direction:', direction);
             return false;
         }
-        
-        const windowState = this._edgeTilingManager.getWindowState(window);
-        const isWindowTiled = windowState && windowState.zone !== TileZone.NONE;
-        
+
         switch (neighbor.type) {
             case 'mosaic':
                 if (isWindowTiled) {

--- a/extension/tiling.js
+++ b/extension/tiling.js
@@ -1884,11 +1884,13 @@ export const TilingManager = GObject.registerClass({
         // No reference window means nothing to eject, so try miniaturizing candidates to reclaim space.
         if (overflow && !reference_meta_window && !this.isDragging && this._extension?.miniatureManager) {
             const focusedId = global.display.focus_window?.get_id();
+            const resizingId = this._animationsManager?.getResizingWindowId();
 
             const overflowCandidates = meta_windows
                 .filter(w =>
                     !WindowState.get(w, IS_MINIATURE) &&
                     w.get_id() !== focusedId &&
+                    w.get_id() !== resizingId &&
                     w.get_id() !== (this._restoringWindowId ?? null) &&
                     !this._windowingManager.isMaximizedOrFullscreen(w)
                 )
@@ -2556,6 +2558,9 @@ export const TilingManager = GObject.registerClass({
         // Reset rebalance counter for this new smart resize cycle
         this._extension?.resizeHandler?.resetConstraintRebalanceCount();
 
+        // Also exclude the window under an active manual resize grab, since focusedWindowOverride can point elsewhere.
+        const resizingWindowId = this._animationsManager?.getResizingWindowId();
+
         try {
             const allResizable = [];
             const allWindows = [];
@@ -2657,7 +2662,7 @@ export const TilingManager = GObject.registerClass({
                     for (const w of orderedWindows0) {
                         const d = windowData.get(w.get_id());
                         if (!d || d.pendingMiniature) continue;
-                        if (w.get_id() === focusedId0 || this._isRecentlyAdded(w)) continue;
+                        if (w.get_id() === focusedId0 || w.get_id() === resizingWindowId || this._isRecentlyAdded(w)) continue;
                         if (WindowState.get(w, IS_MINIATURE)) continue;
                         if (this._windowingManager.isMaximizedOrFullscreen(w)) continue;
                         if (!d.isResizable) continue;
@@ -2722,7 +2727,7 @@ export const TilingManager = GObject.registerClass({
                         const d = windowData.get(sim.id);
                         if (!d) return false;
                         if (d.pendingMiniature) return false;
-                        if (sim.id === focusedId || this._isRecentlyAdded(d.window)) return false;
+                        if (sim.id === focusedId || sim.id === resizingWindowId || this._isRecentlyAdded(d.window)) return false;
                         if (WindowState.get(d.window, IS_MINIATURE)) return false;
                         if (this._windowingManager.isMaximizedOrFullscreen(d.window)) return false;
                         const { thresholdW, thresholdH } = getMiniatureThreshold(d.window);

--- a/extension/tiling.js
+++ b/extension/tiling.js
@@ -736,6 +736,20 @@ export const TilingManager = GObject.registerClass({
         return score;
     }
 
+    // Distance from the restored window's center to the slot its miniature held (Infinity if absent).
+    _restoreDisplacement(tileResult) {
+        if (!this._restoreAnchor) return 0;
+        for (const level of tileResult.levels) {
+            for (const w of level.windows) {
+                if (w.id !== this._restoreAnchor.id) continue;
+                const px = (w.targetX ?? level.x) + w.width / 2;
+                const py = (w.targetY ?? level.y) + w.height / 2;
+                return Math.hypot(px - this._restoreAnchor.cx, py - this._restoreAnchor.cy);
+            }
+        }
+        return Infinity;
+    }
+
     // Find optimal ordering via permutations (with stability bonus for current order)
     _findOptimalOrder(windows, workArea, tilingFn) {
         if (windows.length <= 1) return windows;
@@ -746,6 +760,7 @@ export const TilingManager = GObject.registerClass({
 
         let bestOrder = windows;
         let bestScore = -Infinity;
+        let bestBucket = Infinity;
 
         for (const perm of permutations) {
             const result = tilingFn.call(this, perm, workArea, constants.WINDOW_SPACING);
@@ -758,14 +773,20 @@ export const TilingManager = GObject.registerClass({
                 if (isSameOrder) score += 5;
             }
 
-            if (score > bestScore) {
+            // A just-restored window makes proximity the primary pick, with the base score breaking ties inside the tolerance bucket.
+            const bucket = this._restoreAnchor
+                ? Math.round(this._restoreDisplacement(result) / constants.RESTORE_PROXIMITY_TOLERANCE_PX)
+                : 0;
+
+            if (bucket < bestBucket || (bucket === bestBucket && score > bestScore)) {
+                bestBucket = bucket;
                 bestScore = score;
                 bestOrder = perm;
             }
         }
 
         const elapsed = Date.now() - startTime;
-        Logger.log(`_findOptimalOrder: ${windows.length} windows, ${permutations.length} permutations, ${elapsed}ms`);
+        Logger.log(`_findOptimalOrder: ${windows.length} windows, ${permutations.length} permutations, ${elapsed}ms${this._restoreAnchor ? ` (restore anchor ${this._restoreAnchor.id})` : ''}`);
 
         return bestOrder;
     }
@@ -1798,10 +1819,22 @@ export const TilingManager = GObject.registerClass({
             this._positionSnapshot.set(w.get_id(), { cx: f.x + f.width / 2, cy: f.y + f.height / 2 });
         }
 
+        // Pull a just-restored window back toward its old miniature slot. The restore
+        // path tiles with a null reference, so find the flagged window among these.
+        this._restoreAnchor = null;
+        for (const w of meta_windows) {
+            const rc = WindowState.get(w, 'restoreAnchorCenter');
+            if (rc) {
+                this._restoreAnchor = { id: w.get_id(), cx: rc.cx, cy: rc.cy };
+                break;
+            }
+        }
+
         // Zero-displacement bias makes stability scoring revert explicit drag order; suppress once.
         if (this._skipStabilityForNextTile) {
             this._skipStabilityForNextTile = false;
             this._positionSnapshot = null;
+            this._restoreAnchor = null;
         }
 
         let tile_info = this._tile(windows, tileArea, dryRun);
@@ -1818,6 +1851,7 @@ export const TilingManager = GObject.registerClass({
         // DRY RUN: If dryRun flag is set, return overflow without moving anything
         if (dryRun) {
             this._positionSnapshot = null;
+            this._restoreAnchor = null;
             this._unlockWorkspaceEarlyReturn(workspace);
             return { overflow, layout: this._cachedTileResult?.windows || null };
         }
@@ -1854,6 +1888,7 @@ export const TilingManager = GObject.registerClass({
                         if (!resizeResult?.success) {
                             Logger.log('Smart resize could not fit sacred window');
                             this._positionSnapshot = null;
+                            this._restoreAnchor = null;
                             this._unlockWorkspaceEarlyReturn(workspace);
                             return { overflow: true, layout: null };
                         }
@@ -1944,6 +1979,7 @@ export const TilingManager = GObject.registerClass({
         }
 
         this._positionSnapshot = null;
+        this._restoreAnchor = null;
         if (tile_info?.levels?.length > 0) {
             this._lastTiledOrder = tile_info.levels.flatMap(l => l.windows).map(w => w.id);
             const newGroupAssignment = new Map();
@@ -1982,6 +2018,12 @@ export const TilingManager = GObject.registerClass({
 
         // Create miniatures for pending windows. Top-level only, not inside recursive tryFitWithResize.
         if (!isRecursive) {
+            // Consume any restore anchor so it can't bleed into a later retile.
+            for (const w of meta_windows) {
+                if (WindowState.get(w, 'restoreAnchorCenter'))
+                    WindowState.remove(w, 'restoreAnchorCenter');
+            }
+
             if (this._pendingMiniatureWindows?.length > 0 && this._extension?.miniatureManager) {
                 for (const { window: win, preSize } of this._pendingMiniatureWindows) {
                     // Skip if already miniaturized, since an earlier tile call may have created it first.

--- a/extension/tiling.js
+++ b/extension/tiling.js
@@ -3,6 +3,7 @@
 // Core mosaic tiling algorithm and layout management
 
 import Clutter from 'gi://Clutter'; // Used for Enums (AnimationMode, etc)
+import GLib from 'gi://GLib';
 import GObject from 'gi://GObject';
 import Meta from 'gi://Meta';
 
@@ -27,6 +28,31 @@ const POSITION_STABILITY_WEIGHT = 40;
 // High enough to beat the other terms combined (they max out at 140), so
 // keeping a window's column/shelf wins unless that option would overflow.
 const GROUP_STABILITY_WEIGHT = 150;
+
+// Every ordered composition of n into 1..n groups (n=3 gives [3],[2,1],[1,2],[1,1,1]).
+// A lazy generator on purpose: the count is 2^(n-1), so callers iterate under a time
+// budget and stop early instead of materializing all of it for a huge window count.
+export function* generateRowCompositions(n) {
+    if (n <= 0) return;
+    if (n === 1) { yield [1]; return; }
+
+    function* build(remaining, groupsLeft, acc) {
+        if (remaining === 0) {
+            yield acc.slice();
+            return;
+        }
+        if (groupsLeft === 0) return;
+        // Reserve at least one window per remaining group so we never overshoot.
+        const maxFirst = groupsLeft === 1 ? remaining : remaining - (groupsLeft - 1);
+        for (let first = 1; first <= maxFirst; first++) {
+            acc.push(first);
+            yield* build(remaining - first, groupsLeft - 1, acc);
+            acc.pop();
+        }
+    }
+    for (let groups = 1; groups <= n; groups++)
+        yield* build(n, groups, []);
+}
 
 // Keyed by window ID internally to survive GI reference churn; API mirrors WeakMap
 const _computedLayouts = new Map();
@@ -67,6 +93,12 @@ export const TilingManager = GObject.registerClass({
         this._isSmartResizingBlocked = false;
         // Window ID being restored from miniature; shields it from the overflow handler
         this._restoringWindowId = null;
+
+        // Composition (windows-per-row shape) a deliberate drag/keyboard action pinned
+        // per workspace, so a non-default layout survives the next re-tile. WeakMap since
+        // it is keyed by workspace GObjects that come and go (like _workspaceSwaps).
+        this._pinnedComposition = new WeakMap();
+        this._activePinnedShape = null;
 
         // Layout cache to avoid redundant O(n!) permutation calculations
         this._lastLayoutHash = null;
@@ -348,6 +380,7 @@ export const TilingManager = GObject.registerClass({
     // Pre-compute all valid mosaic layouts for a drag session
     computeDragLayouts(windowDescriptors, workArea, draggedId) {
         const spacing = constants.WINDOW_SPACING;
+        const startTime = GLib.get_monotonic_time();
 
         let maxHeight = 0, maxWidth = 0;
         for (const w of windowDescriptors) {
@@ -358,33 +391,51 @@ export const TilingManager = GObject.registerClass({
         const tooWide = maxWidth > workArea.width * 0.9;
         const tooTall = maxHeight > workArea.height * 0.65;
         const useVertical = tooTall || isNarrow || tooWide;
-        const tilingFn = useVertical ? this._verticalShelves : this._horizontalShelves;
 
-        const perms = this._generatePermutations(windowDescriptors);
+        const n = windowDescriptors.length;
+        const dragged = windowDescriptors.find(w => w.id === draggedId);
+        if (!dragged) return [];
+        const others = windowDescriptors.filter(w => w.id !== draggedId);
+
         const layouts = [];
         const seenPositions = new Set();
+        let shapeCount = 0;
 
-        for (const perm of perms) {
-            const result = tilingFn.call(this, perm, workArea, spacing);
-            if (result.overflow) continue;
+        outer:
+        for (const shape of generateRowCompositions(n)) {
+            // Budget check per shape too, since the generator is lazy and stopping here
+            // caps generation (2^(n-1)) not just the inner loop.
+            if ((GLib.get_monotonic_time() - startTime) / 1000 > constants.DRAG_LAYOUT_TIME_BUDGET_MS)
+                break;
+            shapeCount++;
+            // Put the dragged window in each slot; keep the others in their stable order.
+            for (let slot = 0; slot < n; slot++) {
+                const ordered = [...others];
+                ordered.splice(slot, 0, dragged);
 
-            const positions = this._extractLayoutPositions(result, workArea);
-            const draggedPos = positions.find(p => p.id === draggedId);
-            if (!draggedPos) continue;
+                const result = this._placeByShape(ordered, workArea, spacing, shape, useVertical);
+                if (result.overflow) continue;
 
-            // De-duplicate by 50px grid snap
-            const snapKey = `${Math.round(draggedPos.x / 50)},${Math.round(draggedPos.y / 50)}`;
-            if (seenPositions.has(snapKey)) continue;
-            seenPositions.add(snapKey);
+                const positions = this._extractLayoutPositions(result, workArea);
+                const draggedPos = positions.find(p => p.id === draggedId);
+                if (!draggedPos) continue;
 
-            layouts.push({
-                draggedRect: draggedPos,
-                positions: positions,
-                permOrder: perm.map(w => w.id)
-            });
+                const snapKey = `${Math.round(draggedPos.x / 50)},${Math.round(draggedPos.y / 50)}`;
+                if (seenPositions.has(snapKey)) continue;
+                seenPositions.add(snapKey);
+
+                layouts.push({
+                    draggedRect: draggedPos,
+                    positions,
+                    permOrder: ordered.map(w => w.id),
+                    shape,
+                });
+
+                if (layouts.length >= constants.MAX_DRAG_LAYOUTS) break outer;
+            }
         }
 
-        Logger.log(`computeDragLayouts: ${perms.length} permutations → ${layouts.length} unique positions for window ${draggedId}`);
+        Logger.log(`computeDragLayouts: ${shapeCount} shapes, ${layouts.length} unique positions for window ${draggedId} in ${((GLib.get_monotonic_time() - startTime) / 1000).toFixed(1)}ms`);
         return layouts;
     }
 
@@ -552,6 +603,73 @@ export const TilingManager = GObject.registerClass({
         this._workspaceSwaps.set(workspace, filtered);
         // Pre-drag positions still in snapshot next call; stability heuristic would revert this order.
         this._skipStabilityForNextTile = true;
+    }
+
+    // Persist a chosen composition for the workspace. Ordering rides the existing order-op
+    // path; only the shape is new. Honored by _tile until the window count changes or the
+    // shape stops fitting.
+    pinComposition(workspace, shape, order) {
+        this._pinnedComposition.set(workspace, { count: order.length, shape });
+        Logger.log(`pinComposition: pinned shape [${shape.join(',')}] for ${order.length} windows`);
+        this.applyOrderOp(workspace, order);
+    }
+
+    // Pick the composition that moves the focused window's center farthest in `direction`.
+    // Returns { shape, order, displacement } or null if nothing beats the min threshold.
+    bestRecomposition(workspace, monitor, focusedWindow, direction) {
+        const startTime = GLib.get_monotonic_time();
+        let meta_windows = this._windowingManager.getMonitorWorkspaceWindows(workspace, monitor);
+
+        // Only mosaic windows take part; edge-tiled ones keep their fixed slots and would
+        // otherwise inflate n and make the real tile's window count mismatch the pin.
+        let workArea = workspace.get_work_area_for_monitor(monitor);
+        if (this._edgeTilingManager) {
+            const edgeTiled = this._edgeTilingManager.getEdgeTiledWindows(workspace, monitor);
+            if (edgeTiled.length > 0) {
+                const edgeIds = edgeTiled.map(s => s.window.get_id());
+                meta_windows = meta_windows.filter(w => !edgeIds.includes(w.get_id()));
+                // The mosaic lives in the space left over by the edge tiles, so fit there.
+                workArea = this._edgeTilingManager.calculateRemainingSpace(workspace, monitor);
+            }
+        }
+
+        const descriptors = this.windowsToDescriptors(meta_windows, monitor, focusedWindow);
+        const n = descriptors.length;
+        if (n < 2) return null;
+
+        const spacing = constants.WINDOW_SPACING;
+        const maxH = Math.max(...descriptors.map(w => w.height));
+        const maxW = Math.max(...descriptors.map(w => w.width));
+        const useVertical = maxH > workArea.height * 0.65 || workArea.width < workArea.height || maxW > workArea.width * 0.9;
+
+        const focused = descriptors.find(w => w.id === focusedWindow.get_id());
+        if (!focused) return null;
+        const others = descriptors.filter(w => w.id !== focusedWindow.get_id());
+        const f0 = focusedWindow.get_frame_rect();
+        const cur = { cx: f0.x + f0.width / 2, cy: f0.y + f0.height / 2 };
+        const sign = direction === 'right' || direction === 'down' ? 1 : -1;
+        const axis = direction === 'left' || direction === 'right' ? 'x' : 'y';
+
+        let best = null;
+        for (const shape of generateRowCompositions(n)) {
+            // Same budget as the drag path, since the generator is lazy and n can be large.
+            if ((GLib.get_monotonic_time() - startTime) / 1000 > constants.DRAG_LAYOUT_TIME_BUDGET_MS)
+                break;
+            for (let slot = 0; slot < n; slot++) {
+                const ordered = [...others];
+                ordered.splice(slot, 0, focused);
+                const result = this._placeByShape(ordered, workArea, spacing, shape, useVertical);
+                if (result.overflow) continue;
+                const positions = this._extractLayoutPositions(result, workArea);
+                const fp = positions.find(p => p.id === focusedWindow.get_id());
+                if (!fp) continue;
+                const center = axis === 'x' ? fp.x + fp.width / 2 : fp.y + fp.height / 2;
+                const disp = sign * (center - (axis === 'x' ? cur.cx : cur.cy));
+                if (disp >= constants.KEYBOARD_RECOMPOSE_MIN_DISPLACEMENT_PX && (!best || disp > best.displacement))
+                    best = { shape, order: ordered.map(w => w.id), displacement: disp };
+            }
+        }
+        return best;
     }
 
     _swapElements(array, id1, id2) {
@@ -804,8 +922,10 @@ export const TilingManager = GObject.registerClass({
         if (!windows || windows.length === 0) return { levels: [], vertical: false, overflow: false };
 
         const hash = this._getLayoutHash(windows, work_area);
-        // Skip cache during drag (order changes but hash doesn't)
-        if (this._cachedTileResult && this._lastLayoutHash === hash && !isSimulation && !this.isDragging) {
+        // Skip cache during drag (order changes but hash doesn't) and while a pin is
+        // active, since the hash ignores shape so a new pin would hit a stale cached
+        // layout and revert.
+        if (this._cachedTileResult && this._lastLayoutHash === hash && !isSimulation && !this.isDragging && !this._activePinnedShape) {
             Logger.log('_tile: Cache hit, reusing layout');
             return this._cachedTileResult;
         }
@@ -827,6 +947,20 @@ export const TilingManager = GObject.registerClass({
         
         // Select tiling function based on orientation
         const tilingFn = useVerticalShelves ? this._verticalShelves : this._horizontalShelves;
+
+        // A pinned composition wins over the auto-chosen grid, but only for the real
+        // apply (not simulations / drag) and only while it still fits. If it overflows,
+        // fall through to the normal path so overflow -> miniaturization still runs.
+        if (this._activePinnedShape && !isSimulation && !this.isDragging) {
+            const pinned = this._placeByShape(windows, work_area, spacing, this._activePinnedShape, useVerticalShelves);
+            if (!pinned.overflow) {
+                this._lastLayoutHash = hash;
+                this._cachedTileResult = pinned;
+                Logger.log(`_tile: ${windows.length} windows honoring pinned shape [${this._activePinnedShape.join(',')}]`);
+                return pinned;
+            }
+            Logger.log('_tile: pinned shape overflows, dropping to auto-layout');
+        }
 
         const currentResult = tilingFn.call(this, windows, work_area, spacing);
         let result;
@@ -1144,6 +1278,84 @@ export const TilingManager = GObject.registerClass({
             levels: levels,
             windows: windows
         };
+    }
+
+    // Force windows into an explicit shape instead of the auto-chosen grid (drag/keyboard/pin).
+    _placeByShape(windows, work_area, spacing, shape, vertical) {
+        const groups = [];
+        let idx = 0;
+        for (const count of shape) {
+            const g = [];
+            for (let i = 0; i < count && idx < windows.length; i++) g.push(windows[idx++]);
+            groups.push(g);
+        }
+
+        const levels = [];
+        let overflow = false;
+
+        if (!vertical) {
+            let totalHeight = 0;
+            for (let r = 0; r < groups.length; r++) {
+                const level = new Level(work_area);
+                for (const w of groups[r]) {
+                    level.windows.push(w);
+                    if (level.width > 0) level.width += spacing;
+                    level.width += w.width;
+                    level.height = Math.max(level.height, w.height);
+                }
+                if (level.width > work_area.width) overflow = true;
+                level.x = Math.max(work_area.x, (work_area.width - level.width) / 2 + work_area.x);
+                if (r > 0) totalHeight += spacing;
+                totalHeight += level.height;
+                levels.push(level);
+            }
+            if (totalHeight > work_area.height) overflow = true;
+
+            const y = Math.max(work_area.y, (work_area.height - totalHeight) / 2 + work_area.y);
+            let levelY = y;
+            for (const level of levels) {
+                level.y = levelY;
+                let xPos = level.x;
+                for (const w of level.windows) {
+                    w.targetX = xPos;
+                    w.targetY = levelY + (level.height - w.height) / 2;
+                    xPos += w.width + spacing;
+                }
+                levelY += level.height + spacing;
+            }
+            return { x: work_area.x, y, overflow, vertical: false, levels, windows };
+        }
+
+        let totalWidth = 0;
+        for (let c = 0; c < groups.length; c++) {
+            const level = new Level(work_area);
+            for (const w of groups[c]) {
+                level.windows.push(w);
+                if (level.height > 0) level.height += spacing;
+                level.height += w.height;
+                level.width = Math.max(level.width, w.width);
+            }
+            if (level.height > work_area.height) overflow = true;
+            if (c > 0) totalWidth += spacing;
+            totalWidth += level.width;
+            levels.push(level);
+        }
+        if (totalWidth > work_area.width) overflow = true;
+
+        const x = Math.max(work_area.x, (work_area.width - totalWidth) / 2 + work_area.x);
+        let levelX = x;
+        for (const level of levels) {
+            level.x = levelX;
+            const colHeight = level.windows.reduce((s, w, i) => s + w.height + (i > 0 ? spacing : 0), 0);
+            let yPos = Math.max(work_area.y, (work_area.height - colHeight) / 2 + work_area.y);
+            for (const w of level.windows) {
+                w.targetX = levelX + (level.width - w.width) / 2;
+                w.targetY = yPos;
+                yPos += w.height + spacing;
+            }
+            levelX += level.width + spacing;
+        }
+        return { x, y: work_area.y, overflow, vertical: true, levels, windows };
     }
 
     // Helper for 1-2 windows, simple centered row.
@@ -1837,7 +2049,18 @@ export const TilingManager = GObject.registerClass({
             this._restoreAnchor = null;
         }
 
+        // Honor a pinned composition only if it still matches the current window count.
+        // A count change (window opened/closed) invalidates it, handing control back to
+        // the default auto-layout.
+        this._activePinnedShape = null;
+        const pin = this._pinnedComposition.get(workspace);
+        if (pin) {
+            if (pin.count === windows.length) this._activePinnedShape = pin.shape;
+            else this._pinnedComposition.delete(workspace);
+        }
+
         let tile_info = this._tile(windows, tileArea, dryRun);
+        this._activePinnedShape = null;
         let overflow = tile_info.overflow;
         
         if (workspace_windows.length <= 1) {
@@ -3039,6 +3262,8 @@ export const TilingManager = GObject.registerClass({
         this._cachedTileResult = null;
         this._pendingMiniatureWindows = null;
         this._workspaceSwaps = null;
+        this._pinnedComposition = null;
+        this._activePinnedShape = null;
         this._edgeTilingManager = null;
         this._drawingManager = null;
         this._animationsManager = null;

--- a/extension/tiling.js
+++ b/extension/tiling.js
@@ -82,13 +82,13 @@ export const TilingManager = GObject.registerClass({
         this.tmp_swap = [];
         this.isDragging = false;
         this.dragRemainingSpace = null;
-        
+
         this._edgeTilingManager = null;
         this._drawingManager = null;
         this._animationsManager = null;
         this._windowingManager = null;
         this._extension = null;
-        
+
         // Flag to block overflow decisions during smart resize
         this._isSmartResizingBlocked = false;
         // Window ID being restored from miniature; shields it from the overflow handler
@@ -116,7 +116,7 @@ export const TilingManager = GObject.registerClass({
     setEdgeTilingManager(manager) {
         this._edgeTilingManager = manager;
     }
-    
+
     setExtension(extension) {
         this._extension = extension;
     }
@@ -320,21 +320,21 @@ export const TilingManager = GObject.registerClass({
     clearDragRemainingSpace() {
         this.dragRemainingSpace = null;
     }
-    
+
     setExcludedWindow(window) {
         this._excludedWindow = window;
     }
-    
+
     clearExcludedWindow() {
         this._excludedWindow = null;
     }
-    
+
     // Invalidate the layout cache when windows change
     invalidateLayoutCache() {
         this._lastLayoutHash = null;
         this._cachedTileResult = null;
     }
-    
+
     // Get the cached layout result (array of {id, x, y, width, height})
     getCachedLayout() {
         return this._cachedTileResult?.windows || null;
@@ -675,10 +675,10 @@ export const TilingManager = GObject.registerClass({
     _swapElements(array, id1, id2) {
         const index1 = array.findIndex(w => w.id === id1);
         const index2 = array.findIndex(w => w.id === id2);
-        
+
         if (index1 === -1 || index2 === -1)
             return;
-        
+
         const tmp = array[index1];
         array[index1] = array[index2];
         array[index2] = tmp;
@@ -701,7 +701,7 @@ export const TilingManager = GObject.registerClass({
         if(reference_window)
             if(meta_window.get_id() === reference_window.get_id())
                 return new WindowDescriptor(meta_window, index);
-        
+
         if( this._windowingManager.isExcluded(meta_window) ||
             meta_window.get_monitor() !== monitor ||
             this._windowingManager.isMaximizedOrFullscreen(meta_window))
@@ -723,7 +723,7 @@ export const TilingManager = GObject.registerClass({
     _generatePermutations(arr, maxPermutations = 120) {
         if (arr.length <= 1) return [arr];
         if (arr.length === 2) return [arr, [arr[1], arr[0]]];
-        
+
         // Use heuristic orderings for 6+ windows
         if (arr.length >= 6) {
             const byAreaDesc = [...arr].sort((a, b) => (b.width * b.height) - (a.width * a.height));
@@ -741,7 +741,7 @@ export const TilingManager = GObject.registerClass({
             }
             return candidates;
         }
-        
+
         // Generate all permutations using Heap's algorithm
         const result = [];
         const heap = (n, arr) => {
@@ -767,11 +767,11 @@ export const TilingManager = GObject.registerClass({
     // Prioritizes: no overflow, compactness, centralization
     _scoreLayout(tileResult, workArea) {
         if (!tileResult || tileResult.overflow) return -Infinity;
-        
+
         // Calculate bounding box of all windows
         let minX = Infinity, minY = Infinity, maxX = 0, maxY = 0;
         let totalArea = 0;
-        
+
         for (const level of tileResult.levels) {
             for (const w of level.windows) {
                 const x = w.targetX || level.x;
@@ -783,32 +783,32 @@ export const TilingManager = GObject.registerClass({
                 totalArea += w.width * w.height;
             }
         }
-        
+
         if (minX === Infinity) return -Infinity;
-        
+
         const bboxWidth = maxX - minX;
         const bboxHeight = maxY - minY;
         const bboxArea = bboxWidth * bboxHeight;
-        
+
         // Score components
         // 1. Compactness: ratio of window area to bounding box area (0-1)
         const compactness = totalArea / Math.max(bboxArea, 1);
-        
+
         // 2. Centralization: how close is the bbox center to workArea center
         const bboxCenterX = minX + bboxWidth / 2;
         const bboxCenterY = minY + bboxHeight / 2;
         const workCenterX = workArea.x + workArea.width / 2;
         const workCenterY = workArea.y + workArea.height / 2;
         const centerDist = Math.sqrt(
-            Math.pow(bboxCenterX - workCenterX, 2) + 
+            Math.pow(bboxCenterX - workCenterX, 2) +
             Math.pow(bboxCenterY - workCenterY, 2)
         );
         const maxDist = Math.sqrt(Math.pow(workArea.width, 2) + Math.pow(workArea.height, 2)) / 2;
         const centralization = 1 - (centerDist / maxDist);
-        
+
         // 3. Size efficiency: smaller bounding box is better
         const sizeEfficiency = 1 - (bboxArea / (workArea.width * workArea.height));
-        
+
         // Weighted score (compactness is most important)
         let score = compactness * 50 + centralization * 30 + sizeEfficiency * 20;
 
@@ -929,9 +929,9 @@ export const TilingManager = GObject.registerClass({
             Logger.log('_tile: Cache hit, reusing layout');
             return this._cachedTileResult;
         }
-        
+
         const spacing = constants.WINDOW_SPACING;
-        
+
         // Check if any window is taller than 50% of workspace height
         let maxHeight = 0;
         let maxWidth = 0;
@@ -939,12 +939,12 @@ export const TilingManager = GObject.registerClass({
             maxHeight = Math.max(maxHeight, w.height);
             maxWidth = Math.max(maxWidth, w.width);
         }
-        
+
         const isNarrowWorkspace = work_area.width < work_area.height;
         const windowTooWide = maxWidth > work_area.width * 0.9;
         const windowTooTall = maxHeight > work_area.height * 0.65;
         const useVerticalShelves = windowTooTall || isNarrowWorkspace || windowTooWide;
-        
+
         // Select tiling function based on orientation
         const tilingFn = useVerticalShelves ? this._verticalShelves : this._horizontalShelves;
 
@@ -988,14 +988,14 @@ export const TilingManager = GObject.registerClass({
 
         return result;
     }
-    
+
     // Vertical shelves layout - windows stack in columns side by side.
     _verticalShelves(windows, work_area, spacing) {
         // For 1-2 windows, use simple centered column
         if (windows.length <= 2) {
             return this._simpleCenteredColumn(windows, work_area, spacing);
         }
-        
+
         // Bin packing without height sorting to preserve swap order
         const columns = []; // Each column: { windows: [], height: 0, width: 0 }
 
@@ -1016,9 +1016,9 @@ export const TilingManager = GObject.registerClass({
 
             // If doesn't fit anywhere, create new column
             if (!placed) {
-                const totalWidth = columns.reduce((s, c) => s + c.width, 0) + 
+                const totalWidth = columns.reduce((s, c) => s + c.width, 0) +
                                    (columns.length > 0 ? columns.length * spacing : 0) + w.width;
-                
+
                 if (totalWidth <= work_area.width || columns.length === 0) {
                     columns.push({ windows: [w], height: w.height, width: w.width });
                 } else {
@@ -1037,16 +1037,16 @@ export const TilingManager = GObject.registerClass({
                 }
             }
         }
-        
+
         // Convert columns to levels for rendering
         const levels = [];
         let totalWidth = 0;
         let overflow = false;
-        
+
         for (let c = 0; c < columns.length; c++) {
             const col = columns[c];
             const level = new Level(work_area);
-            
+
             // Recalculate height for this column's windows
             let colHeight = 0;
             for (const w of col.windows) {
@@ -1056,37 +1056,37 @@ export const TilingManager = GObject.registerClass({
                 level.width = Math.max(level.width, w.width);
             }
             level.height = colHeight;
-            
+
             // Check if column overflows height
             if (level.height > work_area.height) {
                 overflow = true;
             }
-            
+
             // Center column vertically
             level.y = (work_area.height - level.height) / 2 + work_area.y;
-            
+
             // Check width overflow
             if (totalWidth + level.width + spacing > work_area.width && c > 0) {
                 overflow = true;
             }
-            
+
             if (c > 0) totalWidth += spacing;
             totalWidth += level.width;
-            
+
             levels.push(level);
         }
-        
+
         // Calculate horizontal centering, clamped so no column starts left of work area
         const startX = Math.max(work_area.x, (work_area.width - totalWidth) / 2 + work_area.x);
         const levelCount = levels.length;
         const centerColIndex = (levelCount - 1) / 2; // e.g., 0.5 for 2 cols, 1 for 3 cols
-        
+
         // Set X positions for each column with CENTER-POINTING alignment
         let xPos = startX;
         for (let colIdx = 0; colIdx < levelCount; colIdx++) {
             const level = levels[colIdx];
             level.x = xPos;
-            
+
             // Determine horizontal alignment based on column position
             let alignMode = 'center';
             if (levelCount > 1) {
@@ -1096,14 +1096,14 @@ export const TilingManager = GObject.registerClass({
                     alignMode = 'left';  // Right column → push windows left
                 }
             }
-            
+
             // Stack windows vertically (packed, centered vertically)
             let totalColHeight = 0;
             for (const win of level.windows) {
                 totalColHeight += win.height;
             }
             totalColHeight += (level.windows.length - 1) * spacing;
-            
+
             let yPos = Math.max(work_area.y, (work_area.height - totalColHeight) / 2 + work_area.y);
 
             for (const win of level.windows) {
@@ -1118,7 +1118,7 @@ export const TilingManager = GObject.registerClass({
                 win.targetY = yPos;
                 yPos += win.height + spacing;
             }
-            
+
             xPos += level.width + spacing;
         }
 
@@ -1131,7 +1131,7 @@ export const TilingManager = GObject.registerClass({
             windows: windows
         };
     }
-    
+
     // Helper for 1-2 windows in vertical mode.
     _simpleCenteredColumn(windows, work_area, spacing) {
         // Calculate total height if stacked
@@ -1142,16 +1142,16 @@ export const TilingManager = GObject.registerClass({
             totalHeight += w.height;
             maxWidth = Math.max(maxWidth, w.width);
         }
-        
+
         // If windows DON'T fit when stacked, put them side by side in separate columns
         if (totalHeight > work_area.height && windows.length === 2) {
             // Create 2 columns side by side
             const totalWidth = windows[0].width + spacing + windows[1].width;
             const startX = Math.max(work_area.x, (work_area.width - totalWidth) / 2 + work_area.x);
-            
+
             const levels = [];
             let xPos = startX;
-            
+
             for (const w of windows) {
                 const level = new Level(work_area);
                 level.windows.push(w);
@@ -1159,16 +1159,16 @@ export const TilingManager = GObject.registerClass({
                 level.height = w.height;
                 level.x = xPos;
                 level.y = Math.max(work_area.y, (work_area.height - w.height) / 2 + work_area.y);
-                
+
                 w.targetX = level.x;
                 w.targetY = level.y;
-                
+
                 levels.push(level);
                 xPos += w.width + spacing;
             }
-            
+
             const overflow = totalWidth > work_area.width;
-            
+
             return {
                 x: startX,
                 y: work_area.y,
@@ -1178,7 +1178,7 @@ export const TilingManager = GObject.registerClass({
                 windows: windows
             };
         }
-        
+
         // Windows FIT when stacked - use single column
         const level = new Level(work_area);
         for (const w of windows) {
@@ -1209,7 +1209,7 @@ export const TilingManager = GObject.registerClass({
             windows: windows
         };
     }
-    
+
     // Horizontal shelves layout: windows pack into rows stacked top-to-bottom.
     _horizontalShelves(windows, work_area, spacing) {
         // For 1-2 windows, use simple centered row
@@ -1221,40 +1221,40 @@ export const TilingManager = GObject.registerClass({
             windows,
             work_area
         );
-        
+
         // Distribute windows across rows
         const levels = [];
         let windowIndex = 0;
         let totalHeight = 0;
         let overflow = false;
-        
+
         for (let r = 0; r < numRows; r++) {
             const level = new Level(work_area);
             const windowsInThisRow = windowsPerRow[r];
-            
+
             for (let i = 0; i < windowsInThisRow && windowIndex < windows.length; i++) {
                 const w = windows[windowIndex++];
                 if (level.width + w.width + (level.width > 0 ? spacing : 0) > work_area.width) {
                     overflow = true;
                 }
-                
+
                 level.windows.push(w);
                 if (level.width > 0) level.width += spacing;
                 level.width += w.width;
                 level.height = Math.max(level.height, w.height);
             }
-            
+
             level.x = Math.max(work_area.x, (work_area.width - level.width) / 2 + work_area.x);
             if (totalHeight + level.height + spacing > work_area.height && r > 0) {
                 overflow = true;
             }
-            
+
             if (r > 0) totalHeight += spacing;
             totalHeight += level.height;
-            
+
             levels.push(level);
         }
-        
+
         const y = Math.max(work_area.y, (work_area.height - totalHeight) / 2 + work_area.y);
 
         // Set targetX/targetY for each window in each level
@@ -1269,7 +1269,7 @@ export const TilingManager = GObject.registerClass({
             }
             levelY += level.height + spacing;
         }
-        
+
         return {
             x: work_area.x,
             y: y,
@@ -1394,25 +1394,25 @@ export const TilingManager = GObject.registerClass({
             windows: windows
         };
     }
-    
+
     // Calculate optimal grid dimensions using actual window sizes
     _calculateOptimalGrid(windows, work_area) {
         const windowCount = windows.length;
         if (windowCount <= 0) return { rows: 0, windowsPerRow: [] };
         if (windowCount === 1) return { rows: 1, windowsPerRow: [1] };
         if (windowCount === 2) return { rows: 1, windowsPerRow: [2] };
-        
+
         const spacing = constants.WINDOW_SPACING;
         const workspaceAspect = work_area.width / work_area.height;
-        
+
         let bestRows = 1;
         let bestScore = Infinity;
         let bestOverflow = true; // Start assuming everything overflows
-        
+
         // Try different row counts
         for (let rows = 1; rows <= windowCount; rows++) {
             const cols = Math.ceil(windowCount / rows);
-            
+
             // Distribute windows logic (symmetric)
             const windowsPerRow = new Array(rows).fill(0);
             const basePerRow = Math.floor(windowCount / rows);
@@ -1424,7 +1424,7 @@ export const TilingManager = GObject.registerClass({
                 const centerIndex = Math.floor(rows / 2);
                 let left = centerIndex;
                 let right = centerIndex;
-                
+
                 while (remainder > 0) {
                     if (left >= 0 && left < rows) { windowsPerRow[left]++; remainder--; }
                     if (remainder > 0 && right !== left && right >= 0 && right < rows) { windowsPerRow[right]++; remainder--; }
@@ -1432,7 +1432,7 @@ export const TilingManager = GObject.registerClass({
                     right++;
                 }
             }
-            
+
             // SIMULATE ACTUAL PLACEMENT to check fit
             let totalHeight = 0;
             let maxRowWidth = 0;
@@ -1440,12 +1440,12 @@ export const TilingManager = GObject.registerClass({
             let currentRowHeight = 0;
             let currentRowWidth = 0;
             let overflow = false;
-            
+
             for (let r = 0; r < rows; r++) {
                 currentRowHeight = 0;
                 currentRowWidth = 0;
                 const count = windowsPerRow[r];
-                
+
                 for (let i = 0; i < count; i++) {
                     if (windowIndex < windows.length) {
                         const w = windows[windowIndex++];
@@ -1453,15 +1453,15 @@ export const TilingManager = GObject.registerClass({
                         currentRowHeight = Math.max(currentRowHeight, w.height);
                     }
                 }
-                
+
                 if (currentRowWidth > work_area.width + 5) overflow = true;
                 maxRowWidth = Math.max(maxRowWidth, currentRowWidth);
-                
+
                 totalHeight += currentRowHeight + (r > 0 ? spacing : 0);
             }
-            
+
             if (totalHeight > work_area.height + 5) overflow = true;
-            
+
             // Calculate score (Aspect ratio + Empty spaces)
             const layoutWidth = maxRowWidth;
             const layoutHeight = totalHeight;
@@ -1470,7 +1470,7 @@ export const TilingManager = GObject.registerClass({
             const emptySpaces = rows * cols - windowCount;
             // Heavily penalize overflow
             const score = aspectDiff + emptySpaces * 0.3 + (overflow ? 1000 : 0);
-            
+
             // Prefer valid layouts over invalid ones
             if (!overflow && bestOverflow) {
                 // Found first valid layout!
@@ -1485,7 +1485,7 @@ export const TilingManager = GObject.registerClass({
                 }
             }
         }
-        
+
         // Re-generate windowsPerRow for the best result
         const windowsPerRow = new Array(bestRows).fill(0);
         const basePerRow = Math.floor(windowCount / bestRows);
@@ -1497,7 +1497,7 @@ export const TilingManager = GObject.registerClass({
             const centerIndex = Math.floor(bestRows / 2);
             let left = centerIndex;
             let right = centerIndex;
-            
+
             while (remainder > 0) {
                 if (left >= 0 && left < bestRows) { windowsPerRow[left]++; remainder--; }
                 if (remainder > 0 && right !== left && right >= 0 && right < bestRows) { windowsPerRow[right]++; remainder--; }
@@ -1505,7 +1505,7 @@ export const TilingManager = GObject.registerClass({
                 right++;
             }
         }
-        
+
         return { rows: bestRows, windowsPerRow };
     }
 
@@ -1521,29 +1521,29 @@ export const TilingManager = GObject.registerClass({
 
         // Filter out windows still pending in the evaluation queue, since they haven't been processed yet
         meta_windows = meta_windows.filter(w => !WindowState.get(w, 'pendingInQueue'));
-        
+
         // Exclude the reference window only if explicitly requested (for overflow scenarios)
         if (window && excludeFromTiling) {
             const windowId = window.get_id();
             meta_windows = meta_windows.filter(w => w.get_id() !== windowId);
         }
-        
+
         if (this.isDragging && this.dragRemainingSpace && window) {
             const draggedId = window.get_id();
             meta_windows = meta_windows.filter(w => w.get_id() !== draggedId);
         }
-        
+
         // Exclude window marked as overflow (won't fit in mosaic)
         if (this._excludedWindow) {
             const excludedId = this._excludedWindow.get_id();
             meta_windows = meta_windows.filter(w => w.get_id() !== excludedId);
         }
-        
+
         let edgeTiledWindows = [];
         if (this._edgeTilingManager) {
             edgeTiledWindows = this._edgeTilingManager.getEdgeTiledWindows(workspace, current_monitor);
         }
-        
+
         const edgeTiledIds = edgeTiledWindows.map(s => s.window.get_id());
         const nonEdgeTiledMetaWindows = meta_windows.filter(w => !edgeTiledIds.includes(w.get_id()));
 
@@ -1555,10 +1555,10 @@ export const TilingManager = GObject.registerClass({
         }
 
         const _windows = this.windowsToDescriptors(windowsForSwaps, current_monitor, window);
-        
+
         this.applySwaps(workspace, _windows);
         this.applyTmp(_windows);
-        
+
         const windows = [];
         for(const w of _windows)
             windows.push(this.getMask(w));
@@ -1621,7 +1621,7 @@ export const TilingManager = GObject.registerClass({
                         let y_offset = 0;
                         if (center_offset > 0)
                             y_offset = Math.min(center_offset, level.height - windowDesc.height);
-                        
+
                         const window = meta_windows.find(w => w.get_id() === windowDesc.id);
                         if (window) {
                             if (WindowState.get(window, IS_MINIATURE)) {
@@ -1674,7 +1674,7 @@ export const TilingManager = GObject.registerClass({
                         // Use targetX/targetY if set, otherwise calculate
                         const targetX = windowDesc.targetX !== undefined ? windowDesc.targetX : x;
                         const targetY = windowDesc.targetY !== undefined ? windowDesc.targetY : y;
-                        
+
                         const window = meta_windows.find(w => w.get_id() === windowDesc.id);
                         if (window) {
                             if (WindowState.get(window, IS_MINIATURE)) {
@@ -1717,7 +1717,7 @@ export const TilingManager = GObject.registerClass({
                     x += level.width + constants.WINDOW_SPACING;
                 }
             }
-            
+
             this._animationsManager.animateReTiling(windowLayouts, draggedWindow, miniLayouts);
         }
 
@@ -1874,7 +1874,7 @@ export const TilingManager = GObject.registerClass({
                 for (let m = 0; m < nMonitors; m++) {
                     this.tileWorkspaceWindows(workspace, null, m, keep_oversized_windows, excludeFromTiling, dryRun, true);
                 }
-                
+
                 // UNLOCK: The recursive calls will handle their own monitor-specific locks,
                 // but we need to ensure the final state is unlocked after a safe delay.
                 if (this._extension && this._extension.windowHandler) {
@@ -1892,12 +1892,12 @@ export const TilingManager = GObject.registerClass({
                 _monitor = reference_meta_window.get_monitor();
             }
         }
-        
+
         // Invalidate window list cache for this operation
         if (this._windowingManager) {
             this._windowingManager.invalidateWindowsCache();
         }
-        
+
         const working_info = this._getWorkingInfo(workspace, reference_meta_window, _monitor, excludeFromTiling);
         if(!working_info) {
             this._unlockWorkspaceEarlyReturn(workspace);
@@ -1909,16 +1909,16 @@ export const TilingManager = GObject.registerClass({
         const monitor = working_info.monitor;
 
         const workspace_windows = this._windowingManager.getMonitorWorkspaceWindows(workspace, monitor);
-        
+
         let edgeTiledWindows = [];
         if (this._edgeTilingManager) {
             edgeTiledWindows = this._edgeTilingManager.getEdgeTiledWindows(workspace, monitor);
             Logger.log(`tileWorkspaceWindows: Found ${edgeTiledWindows.length} edge-tiled windows`);
         }
-        
+
         if (edgeTiledWindows.length > 0) {
             Logger.log(`Found ${edgeTiledWindows.length} edge-tiled window(s)`);
-            
+
             // Check if we have 2 half-tiles (left + right = fully occupied)
             const zones = edgeTiledWindows.map(w => w.zone);
             Logger.log(`Edge tile zones detected: [${zones.join(', ')}]`);
@@ -1926,9 +1926,9 @@ export const TilingManager = GObject.registerClass({
             const hasRightFull = zones.includes(TileZone.RIGHT_FULL);
             const hasLeftQuarters = zones.some(z => z === TileZone.TOP_LEFT || z === TileZone.BOTTOM_LEFT);
             const hasRightQuarters = zones.some(z => z === TileZone.TOP_RIGHT || z === TileZone.BOTTOM_RIGHT);
-            
+
             Logger.log(`Zone check: leftFull=${hasLeftFull}, rightFull=${hasRightFull}, leftQuarters=${hasLeftQuarters}, rightQuarters=${hasRightQuarters}`);
-            
+
             if ((hasLeftFull || hasLeftQuarters) && (hasRightFull || hasRightQuarters)) {
                 // Don't move windows during drag - just show preview
                 if (this.isDragging) {
@@ -1936,20 +1936,20 @@ export const TilingManager = GObject.registerClass({
                     this._unlockWorkspaceEarlyReturn(workspace);
                     return { overflow: false, layout: null }; // Let preview show but don't move windows
                 }
-                
+
                 Logger.log('Both sides edge-tiled - workspace fully occupied');
-                
+
                 // GUARD: Only trigger mass expulsion if the change was caused by an edge-tiled window (completing the wall)
                 // If a normal window is added to a full workspace, ONLY expel that window.
                 const edgeTiledIds = edgeTiledWindows.map(w => w.window.get_id());
                 const isReferenceEdgeTiled = reference_meta_window && edgeTiledIds.includes(reference_meta_window.get_id());
-                
+
                 const nonEdgeTiledMeta = this._edgeTilingManager.getNonEdgeTiledWindows(workspace, monitor);
-                
+
                 // Move non-edge-tiled windows to new workspace
                 for (const window of nonEdgeTiledMeta) {
                     const isRef = reference_meta_window && window.get_id() === reference_meta_window.get_id();
-                    
+
                     // Expel if:
                     // 1. It's the reference window (the newcomer trying to squeeze in)
                     // 2. OR the reference window IS an edge tile (meaning we just closed the wall on existing windows)
@@ -1961,11 +1961,11 @@ export const TilingManager = GObject.registerClass({
                         }
                     }
                 }
-                
+
                 this._unlockWorkspaceEarlyReturn(workspace);
                 return { overflow: false, layout: null }; // Don't tile, edge-tiled windows stay in place
             }
-            
+
             // Single tile or quarter tiles - calculate remaining space
             const remainingSpace = this._edgeTilingManager.calculateRemainingSpace(workspace, monitor);
             const edgeTiledIds = edgeTiledWindows.map(s => s.window.get_id());
@@ -1977,21 +1977,21 @@ export const TilingManager = GObject.registerClass({
             } else {
                 Logger.log(`Remaining space: x=${remainingSpace.x}, y=${remainingSpace.y}, w=${remainingSpace.width}, h=${remainingSpace.height}`);
                 Logger.log(`Total workspace windows: ${workspace_windows.length}, Non-edge-tiled: ${nonEdgeTiledCount}`);
-                
+
                 // Filter out edge-tiled windows from tiling
                 meta_windows = meta_windows.filter(w => !edgeTiledIds.includes(w.get_id()));
                 Logger.log(`After filtering edge-tiled: ${meta_windows.length} windows to tile`);
-                
+
                 // Also filter out maximized/fullscreen windows (SACRED - never touch them)
                 const beforeMaxFilter = meta_windows.length;
                 meta_windows = meta_windows.filter(w => !this._windowingManager.isMaximizedOrFullscreen(w));
                 if (meta_windows.length < beforeMaxFilter) {
                     Logger.log(`Filtered ${beforeMaxFilter - meta_windows.length} maximized/fullscreen (sacred) windows`);
                 }
-                
+
                 // Set work_area to remaining space for tiling calculations
                 work_area = remainingSpace;
-                
+
                 // If no non-edge-tiled windows, nothing to tile
                 if (meta_windows.length === 0) {
                     Logger.log('No non-edge-tiled windows to tile');
@@ -2000,7 +2000,7 @@ export const TilingManager = GObject.registerClass({
                 }
             }
         }
-        
+
         // Only reset if not already populated (to survive recursive calls from tryFitWithResize)
         if (!this._pendingMiniatureWindows) {
             this._pendingMiniatureWindows = [];
@@ -2062,7 +2062,7 @@ export const TilingManager = GObject.registerClass({
         let tile_info = this._tile(windows, tileArea, dryRun);
         this._activePinnedShape = null;
         let overflow = tile_info.overflow;
-        
+
         if (workspace_windows.length <= 1) {
             overflow = false;
         } else {
@@ -2070,7 +2070,7 @@ export const TilingManager = GObject.registerClass({
                 if(this._windowingManager.isMaximizedOrFullscreen(window))
                     overflow = true;
         }
-        
+
         // DRY RUN: If dryRun flag is set, return overflow without moving anything
         if (dryRun) {
             this._positionSnapshot = null;
@@ -2081,21 +2081,21 @@ export const TilingManager = GObject.registerClass({
 
         // Block expulsion if edge-tiled (except non-edge ref); defer if dragging.
         const hasEdgeTiledWindows = edgeTiledWindows && edgeTiledWindows.length > 0;
-        const referenceIsEdgeTiled = reference_meta_window && 
+        const referenceIsEdgeTiled = reference_meta_window &&
             edgeTiledWindows?.some(s => s.window.get_id() === reference_meta_window.get_id());
         const canOverflow = !hasEdgeTiledWindows || !referenceIsEdgeTiled;
-        
+
         if(overflow && !keep_oversized_windows && reference_meta_window && canOverflow && !this.isDragging) {
             // SAFETY: Only overflow windows that are genuinely new (added within last 2 seconds)
             // This prevents incorrectly expelling existing windows during resize retiling
             const addedTime = WindowState.get(reference_meta_window, 'addedTime');
             const isNewlyAdded = addedTime && (Date.now() - addedTime) < constants.NEW_WINDOW_MINIATURIZE_PROTECTION_MS;
-            
+
             if (!isNewlyAdded && !WindowState.get(reference_meta_window, 'forceOverflow') && !WindowState.get(reference_meta_window, 'isRestoringSacred')) {
                 Logger.log(`Skipping overflow for ${reference_meta_window.get_id()} - not a new window`);
             } else if (WindowState.get(reference_meta_window, 'isSmartResizing') || WindowState.get(reference_meta_window, 'isRestoringSacred')) {
                 Logger.log(`Skipping overflow for ${reference_meta_window.get_id()} - smart resize/sacred restore in progress`);
-                
+
                 // FORCE RESIZE ATTEMPT IF NEEDED
                 // If it's a sacred return, we MUST try to fit it, even if it means squishing everyone.
                 if (WindowState.get(reference_meta_window, 'isRestoringSacred')) {
@@ -2103,7 +2103,7 @@ export const TilingManager = GObject.registerClass({
                     // windows here are descriptors; re-fetch MetaWindows for tryFitWithResize
                     const realExisting = this._windowingManager.getMonitorWorkspaceWindows(workspace, monitor)
                         .filter(w => w.get_id() !== reference_meta_window.get_id() && !this._windowingManager.isExcluded(w));
-                                          
+
                     // Only try resize if we haven't already (to avoid loops)
                     if (!WindowState.get(reference_meta_window, 'isSmartResizing')) {
                         Logger.log('Triggering Smart Resize for returning sacred window');
@@ -2213,18 +2213,18 @@ export const TilingManager = GObject.registerClass({
             Logger.log(`[GROUP STABILITY] Recorded assignment: ${[...newGroupAssignment].map(([id, idx]) => `${id}->col${idx}`).join(', ')}`);
         }
         Logger.log(`Drawing tiles - isDragging: ${this.isDragging}, using tileArea: x=${tileArea.x}, y=${tileArea.y}`);
-        
+
         // ANIMATIONS
         let animationsHandledPositioning = false;
         if (!this.isDragging && tile_info && tile_info.levels && tile_info.levels.length > 0) {
             const draggedWindow = reference_meta_window;
-            
+
             // Allow animation for windows returning from excluded state
             if (reference_meta_window && WindowState.get(reference_meta_window, 'justReturnedFromExclusion')) {
                 Logger.log(`Allowing animation for returning excluded window ${reference_meta_window.get_id()}`);
                 WindowState.remove(reference_meta_window, 'justReturnedFromExclusion');
             }
-            
+
             animationsHandledPositioning = this._animateTileLayout(workspace, tile_info, tileArea, meta_windows, draggedWindow, computedSlots);
         }
 
@@ -2282,13 +2282,13 @@ export const TilingManager = GObject.registerClass({
         }
 
         Logger.log(`canFitWindow: Checking if window can fit in workspace ${workspace.index()} (relaxed=${relaxed})`);
-        
+
         // Excluded windows (Always on Top, Sticky) coexist with sacred windows and don't participating in tiling.
         if (this._windowingManager.isExcluded(window)) {
             Logger.log('canFitWindow: Window is excluded - always fits (not tiled)');
             return true;
         }
-        
+
         const isIncomingSacred = this._windowingManager.isMaximizedOrFullscreen(window);
         const currentWindows = this._windowingManager.getMonitorWorkspaceWindows(workspace, monitor)
             .filter(w => !WindowState.get(w, 'pendingInQueue'));
@@ -2329,11 +2329,11 @@ export const TilingManager = GObject.registerClass({
         if (this._edgeTilingManager) {
             edgeTiledWindows = this._edgeTilingManager.getEdgeTiledWindows(workspace, monitor);
         }
-        
+
         let availableSpace = working_info.work_area;
         const newWindowId = window.get_id();
 
-        
+
         if (edgeTiledWindows.length > 0) {
             const otherEdgeTiles = edgeTiledWindows.filter(w => w.window.get_id() !== window.get_id());
             const zones = otherEdgeTiles.map(w => w.zone);
@@ -2341,22 +2341,22 @@ export const TilingManager = GObject.registerClass({
             const hasRightFull = zones.includes(TileZone.RIGHT_FULL);
             const hasLeftQuarters = zones.some(z => z === TileZone.TOP_LEFT || z === TileZone.BOTTOM_LEFT);
             const hasRightQuarters = zones.some(z => z === TileZone.TOP_RIGHT || z === TileZone.BOTTOM_RIGHT);
-            
+
             if ((hasLeftFull || hasLeftQuarters) && (hasRightFull || hasRightQuarters)) {
                 Logger.log('canFitWindow: Workspace fully occupied by edge tiles - cannot fit');
                 return false;
             }
-            
+
             availableSpace = this._edgeTilingManager.calculateRemainingSpace(workspace, monitor);
             Logger.log(`canFitWindow: Using remaining space after snap: ${availableSpace.width}x${availableSpace.height}`);
         }
 
         const edgeTiledIds = edgeTiledWindows.map(s => s.window.get_id());
-        
-        const windows = working_info.windows.filter(w => 
+
+        const windows = working_info.windows.filter(w =>
             !edgeTiledIds.includes(w.id)
         );
-        
+
         // targetSmartResizeSize takes priority: preferredSize holds the pre-resize original, which would falsely report overflow.
         const workspaceWindows = workspace.list_windows();
 
@@ -2392,9 +2392,9 @@ export const TilingManager = GObject.registerClass({
                 }
             }
         }
-        
+
         const windowAlreadyInWorkspace = windows.some(w => w.id === newWindowId);
-        
+
         if (!windowAlreadyInWorkspace) {
             let realWidth, realHeight;
 
@@ -2416,16 +2416,16 @@ export const TilingManager = GObject.registerClass({
                     realHeight = preferredSize ? preferredSize.height : frame.height;
                 }
             }
-            
+
             Logger.log(`canFitWindow: Window not in workspace - adding with size ${realWidth}x${realHeight} (preferred=${!!overrideSize || !!WindowState.get(window, 'preferredSize')})`);
-            
+
             const newWindowDescriptor = new WindowDescriptor(window, windows.length);
             newWindowDescriptor.width = realWidth;
             newWindowDescriptor.height = realHeight;
-            
+
             windows.push(newWindowDescriptor);
         }
-        
+
         if (windowAlreadyInWorkspace) {
             Logger.log('canFitWindow: Window already in workspace - checking current layout');
             // Update descriptor size to match reality or override
@@ -2447,7 +2447,7 @@ export const TilingManager = GObject.registerClass({
                 }
             }
         }
-        
+
         // Try to tile with these windows
         const layout = this._tile(windows, availableSpace, relaxed);
         return !layout.overflow;
@@ -2456,15 +2456,15 @@ export const TilingManager = GObject.registerClass({
     // Restore a window's size to its preferred/original dimensions
     restorePreferredSize(window) {
         if (!window) return;
-        
+
         const preferredSize = WindowState.get(window, 'preferredSize') ||
                               WindowState.get(window, 'openingSize');
-                              
+
         if (preferredSize) {
             Logger.log(`restorePreferredSize: Restoring window ${window.get_id()} to ${preferredSize.width}x${preferredSize.height}`);
             const frame = window.get_frame_rect();
             window.move_resize_frame(false, frame.x, frame.y, preferredSize.width, preferredSize.height);
-            
+
             // Clear constraint flags
             WindowState.set(window, 'isSmartResizing', false);
             WindowState.set(window, 'targetSmartResizeSize', null);
@@ -2484,7 +2484,7 @@ export const TilingManager = GObject.registerClass({
 
     // Save the preferred size of a window (called once when window first appears or user manually resizes)
     // This is the TARGET size the window wants to be
-     
+
     savePreferredSize(window) {
         // Skip - smart resize sets preferredSize in commitResizes()
         if (WindowState.get(window, 'isSmartResizing') || WindowState.get(window, 'isReverseSmartResizing')) {
@@ -2523,7 +2523,7 @@ export const TilingManager = GObject.registerClass({
                 return;
             }
         }
-                               
+
         if (size && size.width > 10 && size.height > 10) {
             // Block save during maximize/fullscreen transitions
             if (WindowState.get(window, 'isEnteringSacred')) {
@@ -2532,7 +2532,7 @@ export const TilingManager = GObject.registerClass({
             }
 
             const current = WindowState.get(window, 'preferredSize');
-            
+
             if (!current) {
                 WindowState.set(window, 'preferredSize', size);
                 Logger.log(`savePreferredSize: [INITIAL] Window ${window.get_id()} set to ${size.width}x${size.height}`);
@@ -2553,9 +2553,9 @@ export const TilingManager = GObject.registerClass({
             Logger.log(`savePreferredSize: Could not determine valid preferred size for ${window.get_id()}`);
         }
     }
-    
+
     // Clear preferred size when window is destroyed
-     
+
     clearPreferredSize(window) {
         if (WindowState.has(window, 'preferredSize')) {
             WindowState.remove(window, 'preferredSize');
@@ -2633,20 +2633,20 @@ export const TilingManager = GObject.registerClass({
     }
 
     tryRestoreWindowSizes(windows, workArea, freedWidth, _freedHeight, _workspace, _monitor) {
-        
+
         // Find windows that were shrunk (current size < preferred size)
         const shrunkWindows = [];
         for (const window of windows) {
             if (WindowState.get(window, IS_MINIATURE)) continue;
             const preferredSize = WindowState.get(window, 'preferredSize');
             if (!preferredSize) continue;
-            
+
             const frame = window.get_frame_rect();
             const widthDiff = preferredSize.width - frame.width;
             const heightDiff = preferredSize.height - frame.height;
-            
+
             Logger.log(`tryRestoreWindowSizes: Check ${window.get_id()}: frame=${frame.width}x${frame.height}, pref=${preferredSize.width}x${preferredSize.height}, diff=${widthDiff}x${heightDiff}`);
-            
+
             // Window was shrunk if it's smaller than opening size (2px threshold for rounding)
             if (widthDiff > 2 || heightDiff > 2) {
                 shrunkWindows.push({
@@ -2661,22 +2661,22 @@ export const TilingManager = GObject.registerClass({
                 });
             }
         }
-        
+
         if (shrunkWindows.length === 0) {
             Logger.log('tryRestoreWindowSizes: No shrunk windows to restore (0/3 windows had deficits > 2px)');
             return false;
         }
-        
+
         Logger.log(`tryRestoreWindowSizes: Found ${shrunkWindows.length} shrunk windows`);
-        
+
         // Check if we have valid freed dimensions, otherwise calculate them
         if (freedWidth === null || freedWidth === undefined || isNaN(freedWidth)) {
             Logger.log('tryRestoreWindowSizes: Calculating available space from work area...');
-            
+
             // Calculate currently used space by remaining windows (at their current sizes)
             let _usedWidth = 0;
             let _usedHeight = 0;
-            
+
             if (windows.length > 0) {
                 for (const w of windows) {
                     const f = w.get_frame_rect();
@@ -2686,30 +2686,30 @@ export const TilingManager = GObject.registerClass({
                     _usedHeight += f.height;
                 }
             }
-            
+
             // Use simulation to determine fit
-            freedWidth = workArea.width; 
+            freedWidth = workArea.width;
             _freedHeight = workArea.height;
         }
 
         // Calculate total deficits
         const totalWidthDeficit = shrunkWindows.reduce((sum, w) => sum + w.widthDeficit, 0);
         const totalHeightDeficit = shrunkWindows.reduce((sum, w) => sum + w.heightDeficit, 0);
-        
+
         Logger.log(`tryRestoreWindowSizes: Total deficits: W=${totalWidthDeficit}px, H=${totalHeightDeficit}px`);
 
         if (totalWidthDeficit <= 0 && totalHeightDeficit <= 0) {
             Logger.log('tryRestoreWindowSizes: No deficit to fill');
             return false;
         }
-        
+
         const result = this.findBestRestorationGain(windows, shrunkWindows, workArea);
 
         if (result) {
             const { gain: bestGain, layout: bestLayout } = result;
             // Success! Apply the restoration.
             Logger.log(`tryRestoreWindowSizes: Applying ${Math.round(bestGain * 100)}% restoration`);
-            
+
             for (const sim of bestLayout) {
                 const w = windows.find(win => win.get_id() === sim.id);
                 if (w) {
@@ -2745,7 +2745,7 @@ export const TilingManager = GObject.registerClass({
         }
     }
     // Calculate window area as ratio of workspace area
-     
+
     getWindowAreaRatio(frame, workArea) {
         const windowArea = frame.width * frame.height;
         const workspaceArea = workArea.width * workArea.height;
@@ -2786,7 +2786,7 @@ export const TilingManager = GObject.registerClass({
     // Calculate layouts without moving windows (for Overview)
     calculateLayoutsOnly(targetWorkspace = null, targetMonitor = null) {
         const workspace = targetWorkspace || global.workspace_manager.get_active_workspace();
-        
+
         // Handle monitor index or object
         let monitorIndex = global.display.get_primary_monitor();
         if (targetMonitor !== null && targetMonitor !== undefined) {
@@ -2796,7 +2796,7 @@ export const TilingManager = GObject.registerClass({
             if (focusMon !== undefined && focusMon !== null)
                 monitorIndex = focusMon;
         }
-        
+
         // Pass excludeFromTiling=false to ensure we consider the new window
         const working_info = this._getWorkingInfo(workspace, null, monitorIndex, false);
         if(!working_info) return;
@@ -2808,7 +2808,7 @@ export const TilingManager = GObject.registerClass({
         // Populate ComputedLayouts cache without moving windows (dryRun=true)
         // Must perform the tiling calculation first
         const tile_info = this._tile(windows, work_area);
-        
+
         // Then run the draw phase in dryRun mode to just populate the cache
         this._drawTile(tile_info, work_area, meta_windows, true);
     }
@@ -3311,7 +3311,7 @@ class WindowDescriptor {
 
         this.id = meta_window.get_id();
     }
-    
+
     draw(meta_windows, x, y, masks, isDragging, drawingManager, dryRun = false) {
         const window = meta_windows.find(w => w.get_id() === this.id);
         if (window) {
@@ -3319,7 +3319,7 @@ class WindowDescriptor {
             if (dryRun) return;
 
             const isMask = masks.has(this.id);
-        
+
             if (isDragging) {
                 if (isMask) {
                 // This is the dragged window - draw preview at its target position

--- a/extension/timing.js
+++ b/extension/timing.js
@@ -20,7 +20,7 @@ export function getSlowDownFactor() {
 
 function getWorkspaceSwitchDuration() {
     if (!getAnimationsEnabled()) return 0;
-    
+
     // Adjust for slow down factor if present
     const baseDuration = FALLBACK_ANIMATION_MS;
     return Math.ceil(baseDuration * getSlowDownFactor());
@@ -100,7 +100,7 @@ export class TimeoutRegistry {
 
 export function createDebounced(func, delay, registry) {
     let timeoutId = null;
-    
+
     const debounced = function(...args) {
         if (timeoutId !== null) registry.remove(timeoutId);
         timeoutId = registry.add(delay, () => {
@@ -109,25 +109,25 @@ export function createDebounced(func, delay, registry) {
             return GLib.SOURCE_REMOVE;
         });
     };
-    
+
     debounced.cancel = () => {
         if (timeoutId !== null) {
             registry.remove(timeoutId);
             timeoutId = null;
         }
     };
-    
+
     return debounced;
 }
 
 export function afterWorkspaceSwitch(callback, registry) {
     const duration = getWorkspaceSwitchDuration();
-    
+
     if (duration === 0) {
         callback();
         return;
     }
-    
+
     // Wait for workspace animation duration
     registry.add(duration, () => {
         callback();
@@ -140,7 +140,7 @@ export function afterAnimations(animationsManager, callback, registry, maxWait =
         callback();
         return;
     }
-    
+
     let processed = false;
     let timeoutId = null;
     let signalId = null;
@@ -177,7 +177,7 @@ export function waitForGeometry(window, callback, registry, maxAttempts = consta
         callback(window);
         return;
     }
-    
+
     let signalId = null;
     let timeoutId = null;
     let processed = false;
@@ -216,7 +216,7 @@ export function afterWindowClose(callback, registry) {
         callback();
         return;
     }
-    
+
     const duration = FALLBACK_ANIMATION_MS * getSlowDownFactor();
     registry.add(duration + 50, () => {
         callback();
@@ -231,7 +231,7 @@ export function afterOverviewHidden(callback, registry) {
         callback();
         return;
     }
-    
+
     Logger.log('Waiting for overview to hide...');
 
     // 'done' guards against double execution: without it, the failsafe could

--- a/extension/windowHandler.js
+++ b/extension/windowHandler.js
@@ -1,6 +1,6 @@
 // Copyright 2025-2026 Cleo Menezes Jr.
 // SPDX-License-Identifier: GPL-3.0-or-later
-// WindowHandler - Manages window lifecycle signals and state transitions.
+// WindowHandler manages window lifecycle signals and state transitions.
 
 import GLib from 'gi://GLib';
 import Clutter from 'gi://Clutter';
@@ -111,7 +111,7 @@ export const WindowHandler = GObject.registerClass({
 
                     // Entering/exiting sacred state is owned by resizeHandler, normally
                     // driven by the WM size-change signal. This property notify is a
-                    // backup for apps where that signal doesn't fire reliably - calling
+                    // backup for apps where that signal doesn't fire reliably; calling
                     // these twice for the same transition is safe (see resizeHandler.js).
                     if (this.windowingManager.isMaximizedOrFullscreen(win)) {
                         if (!WindowState.get(win, 'openedMaximized')) {
@@ -148,7 +148,7 @@ export const WindowHandler = GObject.registerClass({
             }));
         });
 
-        // Detect Fullscreen changes - same backup pattern as maximize above.
+        // Detect Fullscreen changes, same backup pattern as maximize above.
         ids.push(window.connect('notify::fullscreen', (win) => {
             if (this.windowingManager.isMaximizedOrFullscreen(win)) {
                 if (!WindowState.get(win, 'openedMaximized')) {
@@ -269,7 +269,6 @@ export const WindowHandler = GObject.registerClass({
         }
 
         if (isNowExcluded) {
-            // Window became excluded - retile remaining windows
             Logger.log(`Window ${windowId} became excluded - retiling without it`);
 
             const frame = window.get_frame_rect();
@@ -301,7 +300,6 @@ export const WindowHandler = GObject.registerClass({
                 return GLib.SOURCE_REMOVE;
             }, 'windowHandler_excludeRetile');
         } else {
-            // Window became included - treat like new window arrival with smart resize
             Logger.log(`Window ${windowId} became included - treating as new window arrival`);
 
             this._timeoutRegistry.add(constants.RETILE_DELAY_MS, () => {
@@ -369,7 +367,7 @@ export const WindowHandler = GObject.registerClass({
         this._ext._miniatureCascadeIds?.delete(candidate.get_id());
         this._ext.miniatureManager.restoreMiniature(candidate, null, { activate: false });
         // 'miniature-restored' signal fires synchronously, _onMiniatureRestored already
-        // ran by the time restoreMiniature returns - calling it again here used to double
+        // ran by the time restoreMiniature returns; calling it again here used to double
         // the whole Smart Resize + retile pass for one restore.
         return true;
     }
@@ -413,7 +411,7 @@ export const WindowHandler = GObject.registerClass({
 
         // When the caller doesn't trust its own freedWidth/freedHeight enough to pass
         // them through (passFreedDimsToRestore: false), gating the attempt on those same
-        // values is pointless - e.g. 'unmanaged' fires early enough that the closed
+        // values is pointless; e.g. 'unmanaged' fires early enough that the closed
         // window's frame already reads 0x0, which used to block the attempt outright
         // even though tryRestoreWindowSizes would have computed available space itself.
         const hasFreedSpace = !passFreedDimsToRestore || (requireBothFreedDims
@@ -442,7 +440,7 @@ export const WindowHandler = GObject.registerClass({
 
         // Resettling because a window just left, so bounce it like an entrance.
         if (restored) {
-            // move_resize_frame above hasn't settled yet - retiling now would read
+            // move_resize_frame above hasn't settled yet; retiling now would read
             // get_frame_rect() before the client acks the new size, hit the layout
             // cache with the stale dimensions, and redraw right back over the restore.
             this._ext._timeoutRegistry.add(constants.RESIZE_SETTLE_DELAY_MS, () => {
@@ -464,9 +462,13 @@ export const WindowHandler = GObject.registerClass({
                 return GLib.SOURCE_REMOVE;
             }, settleTimeoutName);
         } else {
-            this.animationsManager.setMembershipChangeBounce(true);
-            this._ext.tilingManager.tileWorkspaceWindows(workspace, null, monitor, true);
-            this.animationsManager.setMembershipChangeBounce(false);
+            if (Main.overview.visible) {
+                this._pendingRestoreRetiles.push({ workspace, monitor, windows: [] });
+            } else {
+                this.animationsManager.setMembershipChangeBounce(true);
+                this._ext.tilingManager.tileWorkspaceWindows(workspace, null, monitor, true);
+                this.animationsManager.setMembershipChangeBounce(false);
+            }
         }
     }
 
@@ -522,9 +524,9 @@ export const WindowHandler = GObject.registerClass({
             const managedWindows = windows.filter(w => !this.windowingManager.isExcluded(w));
 
             if (managedWindows.length === 0) {
-                // Skip if overflow is in progress - window is being moved and will arrive soon
+                // Skip if overflow is in progress; window is being moved and will arrive soon
                 if (this._overflowInProgress) {
-                    Logger.log('Workspace is empty but overflow in progress - skipping navigation');
+                    Logger.log('Workspace is empty but overflow in progress; skipping navigation');
                     return;
                 }
 
@@ -718,7 +720,7 @@ export const WindowHandler = GObject.registerClass({
             return workspace;
         }
 
-        // Path 1: Sacred Isolation - Symmetric isolation enforcement.
+        // Path 1: Sacred Isolation (symmetric isolation enforcement).
         const isIncomingSacred = this.windowingManager.isMaximizedOrFullscreen(window);
         const hasExistingSacred = this.windowingManager.hasSacredWindow(workspace, monitor, window.get_id());
         const workspaceWindows = this.windowingManager.getMonitorWorkspaceWindows(workspace, monitor)
@@ -1155,7 +1157,7 @@ export const WindowHandler = GObject.registerClass({
                             WORKSPACE.activate(global.get_current_time());
                             this._ext.windowingManager.showWorkspaceSwitcher(WORKSPACE, MONITOR);
 
-                            // Mark as DnD arrival - will trigger expansion after tiling
+                            // Mark as DnD arrival; triggers expansion after tiling
                             WindowState.set(WINDOW, 'arrivedFromDnD', true);
 
                             // Wait for overview to fully close before tiling
@@ -1164,14 +1166,14 @@ export const WindowHandler = GObject.registerClass({
                                 Main.overview.hide();
                             }
 
-                            // Clear DnD tracking - normal flow will handle window
+                            // Clear DnD tracking; normal flow handles the window
                             WindowState.remove(WINDOW, 'previousWorkspace');
                             WindowState.remove(WINDOW, 'removedTimestamp');
                             WindowState.remove(WINDOW, 'manualWorkspaceMove');
                         }
                     }
 
-                    // Mark window as waiting for geometry - prevents premature overflow
+                    // Mark window as waiting for geometry; prevents premature overflow
                     WindowState.set(WINDOW, 'waitingForGeometry', true);
 
                     // Repoll while waitForGeometry returns SOURCE_CONTINUE, bounded

--- a/extension/windowHandler.js
+++ b/extension/windowHandler.js
@@ -269,7 +269,7 @@ export const WindowHandler = GObject.registerClass({
         }
 
         if (isNowExcluded) {
-            Logger.log(`Window ${windowId} became excluded - retiling without it`);
+            Logger.log(`Window ${windowId} became excluded; retiling without it`);
 
             const frame = window.get_frame_rect();
             const freedWidth = frame.width;
@@ -300,7 +300,7 @@ export const WindowHandler = GObject.registerClass({
                 return GLib.SOURCE_REMOVE;
             }, 'windowHandler_excludeRetile');
         } else {
-            Logger.log(`Window ${windowId} became included - treating as new window arrival`);
+            Logger.log(`Window ${windowId} became included; treating as new window arrival`);
 
             this._timeoutRegistry.add(constants.RETILE_DELAY_MS, () => {
                 const workArea = this.edgeTilingManager.calculateRemainingSpace(workspace, monitor);

--- a/extension/windowHandler.js
+++ b/extension/windowHandler.js
@@ -548,7 +548,7 @@ export const WindowHandler = GObject.registerClass({
 
         if (this._pendingRestoreRetiles.length > 0) {
             for (const { workspace: ws, monitor: mon, windows } of this._pendingRestoreRetiles) {
-                Logger.log(`Retiling after restore delay (deferred: overview was open)`);
+                Logger.log('Retiling after restore delay (deferred: overview was open)');
                 this.animationsManager.setMembershipChangeBounce(true);
                 this._ext.tilingManager.tileWorkspaceWindows(ws, null, mon, true);
                 this.animationsManager.setMembershipChangeBounce(false);

--- a/extension/windowHandler.js
+++ b/extension/windowHandler.js
@@ -645,7 +645,7 @@ export const WindowHandler = GObject.registerClass({
                     // Cascade target workspace if a previous window in this batch caused an overflow
                     Logger.log(`Evaluation queue: cascading window ${window.get_id()} to overflow destination WS-${lastOverflowWorkspace.index()}`);
                     workspace = lastOverflowWorkspace;
-                    
+
                     if (window.get_workspace() !== workspace) {
                         WindowState.set(window, 'movedByOverflow', true);
                         window.change_workspace(workspace);
@@ -671,7 +671,7 @@ export const WindowHandler = GObject.registerClass({
                 if (managedWindows.length === 0) {
                     // Only renavigate if the workspace is truly empty and not just being transitioned during overflow
                     const isEjectedByOverflow = lastOverflowWorkspace && lastOverflowWorkspace.index() !== workspace.index();
-                    
+
                     if (!isEjectedByOverflow) {
                         Logger.log(`Queue: Window ${window.get_id()} moved and left WS-${workspace.index()} empty - renavigating`);
                         this.windowingManager.renavigate(workspace, true, this._ext._lastVisitedWorkspace, monitor);

--- a/extension/windowHandler.js
+++ b/extension/windowHandler.js
@@ -489,6 +489,7 @@ export const WindowHandler = GObject.registerClass({
         this.edgeTilingManager.clearWindowState(window);
 
         WindowState.remove(window, 'maximizedUndoInfo');
+        WindowState.remove(window, 'sacredDisplacedWorkspace');
 
         if (this.windowingManager.isExcluded(window)) {
             Logger.log('Excluded window closed - no workspace navigation');

--- a/extension/windowing.js
+++ b/extension/windowing.js
@@ -31,7 +31,7 @@ export const WindowingManager = GObject.registerClass({
         this._timeoutRegistry = null;
         this._overflowStartCallback = null;
         this._overflowEndCallback = null;
-        
+
         // Cache for getMonitorWorkspaceWindows - invalidated at start of each tiling operation
         // WeakMap<Workspace, Map<String, Window[]>>
         this._windowsCache = new WeakMap();
@@ -44,15 +44,15 @@ export const WindowingManager = GObject.registerClass({
     setAnimationsManager(manager) {
         this._animationsManager = manager;
     }
-    
+
     setTilingManager(manager) {
         this._tilingManager = manager;
     }
-    
+
     setTimeoutRegistry(registry) {
         this._timeoutRegistry = registry;
     }
-    
+
     setOverflowCallbacks(startCallback, endCallback) {
         this._overflowStartCallback = startCallback;
         this._overflowEndCallback = endCallback;
@@ -77,7 +77,7 @@ export const WindowingManager = GObject.registerClass({
 
     getMonitorWorkspaceWindows(workspace, monitor, allow_unrelated) {
         if (!workspace) return [];
-        
+
         let workspaceCache = this._windowsCache.get(workspace);
         if (!workspaceCache || workspaceCache._version !== this._cacheVersion) {
             workspaceCache = new Map();
@@ -89,7 +89,7 @@ export const WindowingManager = GObject.registerClass({
         if (workspaceCache.has(cacheKey)) {
             return workspaceCache.get(cacheKey);
         }
-        
+
         const _windows = [];
         const windows = workspace.list_windows();
         for (const window of windows)
@@ -106,18 +106,18 @@ export const WindowingManager = GObject.registerClass({
             Logger.error('tryTileWithSnappedWindow: edgeTilingManager not set');
             return false;
         }
-        
+
         const workspace = window.get_workspace();
         const monitor = window.get_monitor();
         const workArea = workspace.get_work_area_for_monitor(monitor);
-        
+
         const tileState = this._edgeTilingManager.getWindowState(edgeTiledWindow);
-        
+
         if (!tileState || tileState.zone === TileZone.NONE) {
             Logger.log('Existing window is not edge-tiled, cannot tile');
             return false;
         }
-        
+
         let direction;
         if (tileState.zone === TileZone.LEFT_FULL ||
             tileState.zone === TileZone.TOP_LEFT ||
@@ -131,15 +131,15 @@ export const WindowingManager = GObject.registerClass({
             Logger.log('Unsupported edge tile zone for dual-tiling');
             return false;
         }
-        
+
         const existingFrame = edgeTiledWindow.get_frame_rect();
         const existingWidth = existingFrame.width;
         const availableWidth = workArea.width - existingWidth;
-        
+
         Logger.log(`Auto-tiling: existing window width=${existingWidth}px, available=${availableWidth}px`);
-        
+
         let targetX, targetY, targetWidth, targetHeight;
-        
+
         if (direction === 'left') {
             targetX = workArea.x;
             targetY = workArea.y;
@@ -151,24 +151,24 @@ export const WindowingManager = GObject.registerClass({
             targetWidth = availableWidth;
             targetHeight = workArea.height;
         }
-        
+
         try {
             this._edgeTilingManager.saveWindowState(window);
-            
+
             window.unmaximize();
             window.move_resize_frame(false, targetX, targetY, targetWidth, targetHeight);
-            
+
             const zone = direction === 'left' ? TileZone.LEFT_FULL : TileZone.RIGHT_FULL;
             const state = this._edgeTilingManager.getWindowState(window);
             if (state) {
                 state.zone = zone;
                 Logger.log(`Dual-tiling: Updated window ${window.get_id()} state to zone ${zone}`);
-                
+
                 this._edgeTilingManager.setupResizeListener(window);
             }
-            
+
             this._edgeTilingManager.registerAutoTileDependency(window, edgeTiledWindow);
-            
+
             Logger.log(`Successfully dual-tiled window ${window.get_wm_class()} to ${direction} (${targetWidth}x${targetHeight})`);
             return true;
         } catch (error) {
@@ -187,7 +187,7 @@ export const WindowingManager = GObject.registerClass({
         const nextIndex = currentIndex + 1;
         const totalWorkspaces = workspaceManager.get_n_workspaces();
         const nextWorkspace = nextIndex < totalWorkspaces ? workspaceManager.get_workspace_by_index(nextIndex) : null;
-        
+
         let targetWorkspace;
         if (nextWorkspace && nextWorkspace.list_windows().length === 0) {
             Logger.log(`[WORKSPACE] Reusing existing empty workspace at WS-${nextIndex}`);
@@ -197,7 +197,7 @@ export const WindowingManager = GObject.registerClass({
             targetWorkspace = workspaceManager.append_new_workspace(false, this.getTimestamp());
             workspaceManager.reorder_workspace(targetWorkspace, nextIndex);
         }
-        
+
         return targetWorkspace;
     }
 
@@ -207,28 +207,28 @@ export const WindowingManager = GObject.registerClass({
         return new Promise(resolve => {
             const workspaceManager = global.workspace_manager;
             const monitor = window.get_monitor();
-            
+
             // Notify that overflow is starting
             if (this._overflowStartCallback) {
                 this._overflowStartCallback();
             }
-            
+
             // Flag window as overflow-moved to prevent tiling errors
             WindowState.set(window, 'movedByOverflow', true);
-        
+
             // Use current workspace as origin to prevent overflow target loops.
             const currentIndex = window.get_workspace().index();
-        
+
             Logger.log(`moveOversizedWindow: origin=${currentIndex}`);
-        
+
             const isSacred = this.isMaximizedOrFullscreen(window);
             const nextIndex = currentIndex + 1;
             const totalWorkspaces = workspaceManager.get_n_workspaces();
             let target_workspace = null;
-        
+
             // GNOME's dynamic workspaces might not have a workspace at nextIndex yet
             const nextWorkspace = nextIndex < totalWorkspaces ? workspaceManager.get_workspace_by_index(nextIndex) : null;
-        
+
             if (isSacred) {
                 Logger.log(`[PLACEMENT] Sacred window detected - targeting strictly WS-${nextIndex} for isolation`);
                 target_workspace = this.createOrReuseAdjacentWorkspace(workspaceManager.get_workspace_by_index(currentIndex));
@@ -242,7 +242,7 @@ export const WindowingManager = GObject.registerClass({
                     target_workspace = this.createOrReuseAdjacentWorkspace(workspaceManager.get_workspace_by_index(currentIndex));
                 }
             }
-        
+
             const previous_workspace = window.get_workspace();
             const switchFocusRequested = options.switchFocus !== false;
 
@@ -266,16 +266,16 @@ export const WindowingManager = GObject.registerClass({
                         this.showWorkspaceSwitcher(target_workspace, monitor);
                     }
                 }, this._timeoutRegistry);
-                
+
                 // Re-tile after window has settled
                 if (this._tilingManager) {
                     Logger.log('moveOversizedWindow: workspace switch done, retiling immediately and then waiting for animations');
-                    
+
                     // First, repair any aborted smart-resize corruption in the origin workspace before the window was ejected
                     if (previous_workspace.index() !== target_workspace.index()) {
                         this._tilingManager.tileWorkspaceWindows(previous_workspace, null, monitor);
                     }
-                    
+
                     // Tile target workspace IMMEDIATELY to prevent "leap to 0,0"
                     this._tilingManager.tileWorkspaceWindows(target_workspace, null, monitor);
 
@@ -283,7 +283,7 @@ export const WindowingManager = GObject.registerClass({
                         try {
                             // Perfectly tile the target workspace again after GNOME animations finish
                             this._tilingManager.tileWorkspaceWindows(target_workspace, null, monitor);
-                            
+
                             // Check position after tiling
                             this._timeoutRegistry.addIdle(() => {
                                 try {
@@ -295,7 +295,7 @@ export const WindowingManager = GObject.registerClass({
                                     const expectedX = Math.floor((workArea.width - finalFrame.width) / 2) + workArea.x;
                                     const expectedY = Math.floor((workArea.height - finalFrame.height) / 2) + workArea.y;
                                     const positionError = Math.abs(finalFrame.x - expectedX) + Math.abs(finalFrame.y - expectedY);
-                                    
+
                                     if (positionError > 10) {
                                         Logger.log(`moveOversizedWindow: window mispositioned by ${positionError}px, retiling`);
                                         this._tilingManager.tileWorkspaceWindows(target_workspace, null, monitor);
@@ -313,7 +313,7 @@ export const WindowingManager = GObject.registerClass({
                             }, 'windowing_positionCheck', GLib.PRIORITY_DEFAULT_IDLE);
                         } catch (e) {
                             Logger.error(`Error during moveOversizedWindow retiling: ${e}`);
-                            
+
                             WindowState.remove(window, 'movedByOverflow');
                             WindowState.remove(window, 'overflowOriginWorkspace');
 
@@ -332,7 +332,7 @@ export const WindowingManager = GObject.registerClass({
                     }
                     resolve(target_workspace);
                 }
-                
+
                 return GLib.SOURCE_REMOVE;
             });
         });
@@ -342,7 +342,7 @@ export const WindowingManager = GObject.registerClass({
         if (!this.isRelated(meta_window) || meta_window.minimized) {
             return true;
         }
-        
+
         // Always on top (window is above other windows)
         if (meta_window.is_above()) {
             return true;
@@ -382,11 +382,11 @@ export const WindowingManager = GObject.registerClass({
         if (meta_window.is_skip_taskbar()) {
             return false;
         }
-        
+
         if (meta_window.is_on_all_workspaces()) {
             return false;
         }
-        
+
         return true;
     }
 
@@ -439,12 +439,12 @@ export const WindowingManager = GObject.registerClass({
             }
             // 2. Try to move in the direction of the last visited workspace
             else if (lastVisitedIndex !== null && lastVisitedIndex !== currentIndex) {
-                const direction = lastVisitedIndex < currentIndex 
-                    ? Meta.MotionDirection.LEFT 
+                const direction = lastVisitedIndex < currentIndex
+                    ? Meta.MotionDirection.LEFT
                     : Meta.MotionDirection.RIGHT;
-                
+
                 target = workspace.get_neighbor(direction);
-                
+
                 // Guard: Don't jump to the final empty workspace if we were going right
                 if (target && target.index() === lastWorkspaceIndex) {
                     target = null;
@@ -456,11 +456,11 @@ export const WindowingManager = GObject.registerClass({
             // 3. Fallback: Systematic neighbor search (Left, then Right)
             if (!target || target.index() === currentIndex) {
                 target = workspace.get_neighbor(Meta.MotionDirection.LEFT);
-                
+
                 if (!target || target.index() === currentIndex || target.index() < 0) {
                     target = workspace.get_neighbor(Meta.MotionDirection.RIGHT);
                 }
-                
+
                 // Final safety: never fallback to the placeholder workspace
                 if (target && target.index() === lastWorkspaceIndex) {
                     target = null;
@@ -483,23 +483,23 @@ export const WindowingManager = GObject.registerClass({
 
     showWorkspaceSwitcher(workspace, monitorIndex = -1) {
         if (!workspace) return;
-        
+
         const index = workspace.index();
         Logger.log(`[SWITCHER] Activating OSD for WS-${index}`);
-        
+
         // Default to primary monitor if none specified
         if (monitorIndex === -1) {
             monitorIndex = Main.layoutManager.primaryIndex;
         }
-        
+
         Logger.log(`showWorkspaceSwitcher: showing WorkspaceSwitcherPopup for workspace ${index} on monitor ${monitorIndex}`);
-        
+
         // Use WorkspaceSwitcherPopup for native workspace switching indicator (dots/grid)
         try {
             if (!Main.wm._workspaceSwitcherPopup) {
                 Main.wm._workspaceSwitcherPopup = new WorkspaceSwitcherPopup.WorkspaceSwitcherPopup();
             }
-            
+
             // Ensure destruction cleanup
             if (!WindowState.get(Main.wm._workspaceSwitcherPopup, 'destroyConnected')) {
                 Main.wm._workspaceSwitcherPopup.connect('destroy', () => {

--- a/extension/windowing.js
+++ b/extension/windowing.js
@@ -201,6 +201,28 @@ export const WindowingManager = GObject.registerClass({
         return targetWorkspace;
     }
 
+    // Workspace to the left of the origin for displaced windows.
+    createOrReuseLeftWorkspace(originWorkspace) {
+        const workspaceManager = global.workspace_manager;
+        const currentIndex = originWorkspace.index();
+        const prevIndex = currentIndex - 1;
+
+        if (prevIndex >= 0) {
+            const prevWorkspace = workspaceManager.get_workspace_by_index(prevIndex);
+            if (prevWorkspace && prevWorkspace.list_windows().length === 0) {
+                Logger.log(`[WORKSPACE] Reusing existing empty workspace at WS-${prevIndex}`);
+                return prevWorkspace;
+            }
+        }
+
+        // Insert at currentIndex so the new workspace lands immediately to the
+        // left of the origin, even when prevIndex is occupied or doesn't exist.
+        Logger.log(`[WORKSPACE] Creating new workspace and inserting at WS-${currentIndex}`);
+        const targetWorkspace = workspaceManager.append_new_workspace(false, this.getTimestamp());
+        workspaceManager.reorder_workspace(targetWorkspace, currentIndex);
+        return targetWorkspace;
+    }
+
     // Moves a window that doesn't fit into another workspace.
     // Returns a Promise that resolves with the target_workspace when the move and retiling are complete.
     moveOversizedWindow(window, options = { switchFocus: true }) {


### PR DESCRIPTION
Refactor sacred window handling to displace siblings instead of moving maximized window

The maximized/fullscreen window now stays in place while other windows on the monitor are displaced to a new workspace to the left. This avoids a confusing dual motion where the window expands while simultaneously sliding to another workspace.

- Added createOrReuseLeftWorkspace() in windowing.js to create/reuse an empty workspace immediately left of the origin
- tryEnterSacred() now moves sibling windows to the new workspace instead of moving the maximized window itself
- handleUnmaximizeUndo() returns displaced windows to the origin workspace before unmaximizing, so they're visible during the shrink animation
- Simplified unmaximize flow by removing smart-resize fit checks and pending miniature tracking; the two-stage resize-first strategy is now implicit
- Cleaned up obsolete state flags (sacredFitConfirmed, pendingMiniaturesForReturn)

Closes #31

https://github.com/user-attachments/assets/ef2ddb8f-0a6d-4dcc-bf51-c6f3be001277
