### PR TITLE
fix: preserve mosaic layout around maximized and fullscreen windows

### DIFF
--- a/extension/resizeHandler.js
+++ b/extension/resizeHandler.js
@@ -70,6 +70,21 @@ export const ResizeHandler = GObject.registerClass({
         this._constraintRebalanceCount = 0;
     }
 
+    _isMiniatureFrame(window) {
+        return WindowState.get(window, WindowState.IS_MINIATURE) ||
+            WindowState.get(window, WindowState.PENDING_MINIATURE);
+    }
+
+    _discardMiniatureResizeTarget(window) {
+        if (!this._isMiniatureFrame(window) || !WindowState.get(window, 'targetSmartResizeSize'))
+            return false;
+
+        WindowState.remove(window, 'targetSmartResizeSize');
+        this._disarmClampVerification(window);
+        this._sizeChanged = false;
+        return true;
+    }
+
     // Once the client had its chance, a frame still above target is a genuine minimum.
     _commitClampedSize(window, pendingSmartSize, rect) {
         Logger.log(`[SMART RESIZE] Window ${window.get_id()} clamped: target=${pendingSmartSize.width}×${pendingSmartSize.height}, actual=${rect.width}×${rect.height}`);
@@ -112,6 +127,13 @@ export const ResizeHandler = GObject.registerClass({
         const verifyId = this._timeoutRegistry.add(constants.RESIZE_CLAMP_VERIFY_DELAY_MS, () => {
             WindowState.remove(window, 'clampVerifyId');
             if (!isWindowAlive(window)) return GLib.SOURCE_REMOVE;
+
+            // Miniatures intentionally keep their native frame and scale only the actor.
+            // Their visual slot can never be verified through get_frame_rect().
+            if (this._isMiniatureFrame(window)) {
+                WindowState.remove(window, 'targetSmartResizeSize');
+                return GLib.SOURCE_REMOVE;
+            }
 
             // Whatever resolved or replaced this target meanwhile owns the state now.
             const current = WindowState.get(window, 'targetSmartResizeSize');
@@ -356,6 +378,7 @@ export const ResizeHandler = GObject.registerClass({
         const rect = window.get_frame_rect();
         if (this._ignoreSizeChange(window, rect)) return;
 
+        if (this._discardMiniatureResizeTarget(window)) return;
         if (this._handleClampAfterResize(window, rect)) return;
         if (this._handleSacredResizePhase(window)) return;
         if (this._handleMaxUnmaxResize(window)) return;

--- a/extension/resizeHandler.js
+++ b/extension/resizeHandler.js
@@ -256,11 +256,12 @@ export const ResizeHandler = GObject.registerClass({
     // fullscreen doesn't reliably trigger window_manager's size-change signal, so
     // this is also called from windowHandler's notify::fullscreen as a backup -
     // the pending flag below makes calling it twice for the same transition safe.
-    // size-change fires BEFORE window-created for new windows, so a window with no
-    // preferredSize/openingSize hasn't been through onWindowCreated yet; if it's already
-    // maximized it was born that way and skips isolation.
+    // size-change fires BEFORE window-created for new windows. Once geometryReady is set,
+    // a maximize is necessarily a later user action even when the client never supplied a
+    // usable saved size.
     _detectBornMaximized(window) {
-        if (!WindowState.get(window, 'preferredSize') &&
+        if (!WindowState.get(window, 'geometryReady') &&
+            !WindowState.get(window, 'preferredSize') &&
             !WindowState.get(window, 'openingSize') &&
             this.windowingManager.isMaximizedOrFullscreen(window)) {
             WindowState.set(window, 'openedMaximized', true);

--- a/extension/resizeHandler.js
+++ b/extension/resizeHandler.js
@@ -243,19 +243,40 @@ export const ResizeHandler = GObject.registerClass({
     onSizeChange = (_, win, mode) => {
         const window = win.meta_window;
         if (!this.windowingManager.isExcluded(window)) {
-            if (mode === Meta.SizeChange.FULLSCREEN || mode === Meta.SizeChange.MAXIMIZE) {
+            if (mode === Meta.SizeChange.FULLSCREEN || mode === Meta.SizeChange.UNFULLSCREEN) {
+                this.handleFullscreenTransition(window);
+            } else if (mode === Meta.SizeChange.MAXIMIZE) {
                 this.tryEnterSacred(window);
-            } else if (mode === Meta.SizeChange.UNMAXIMIZE || mode === Meta.SizeChange.UNFULLSCREEN) {
+            } else if (mode === Meta.SizeChange.UNMAXIMIZE) {
                 this.tryExitSacred(window);
             }
         }
     };
 
-    // Isolates a maximized/fullscreen window to its own workspace, after a short
-    // debounce so a quick toggle back never even starts the move. Some apps'
-    // fullscreen doesn't reliably trigger window_manager's size-change signal, so
-    // this is also called from windowHandler's notify::fullscreen as a backup -
-    // the pending flag below makes calling it twice for the same transition safe.
+    // Fullscreen is a compositor overlay on the current mosaic. Consume the frame
+    // changes on both sides of the transition so they cannot rewrite or retile it.
+    // notify::fullscreen calls this too because some clients omit the WM signal.
+    handleFullscreenTransition(window) {
+        WindowState.set(window, 'fullscreenTransition', true);
+        WindowState.remove(window, 'isEnteringSacred');
+
+        const previousTimeout = WindowState.get(window, 'fullscreenTransitionTimeout');
+        if (previousTimeout) this._timeoutRegistry.remove(previousTimeout);
+
+        const timeoutId = this._timeoutRegistry.add(
+            constants.RETILE_DELAY_MS + constants.RESIZE_SETTLE_DELAY_MS,
+            () => {
+                WindowState.remove(window, 'fullscreenTransition');
+                WindowState.remove(window, 'fullscreenTransitionTimeout');
+                return GLib.SOURCE_REMOVE;
+            },
+            'resizeHandler_fullscreenTransition'
+        );
+        WindowState.set(window, 'fullscreenTransitionTimeout', timeoutId);
+    }
+
+    // Isolates a maximized window to its own workspace, after a short debounce
+    // so a quick toggle back never even starts the move.
     // size-change fires BEFORE window-created for new windows. Once geometryReady is set,
     // a maximize is necessarily a later user action even when the client never supplied a
     // usable saved size.
@@ -263,7 +284,7 @@ export const ResizeHandler = GObject.registerClass({
         if (!WindowState.get(window, 'geometryReady') &&
             !WindowState.get(window, 'preferredSize') &&
             !WindowState.get(window, 'openingSize') &&
-            this.windowingManager.isMaximizedOrFullscreen(window)) {
+            window.is_maximized() && !window.is_fullscreen()) {
             WindowState.set(window, 'openedMaximized', true);
             Logger.log(`tryEnterSacred: Detected born-maximized window ${window.get_id()} - skipping isolation`);
             return true;
@@ -272,6 +293,10 @@ export const ResizeHandler = GObject.registerClass({
     }
 
     tryEnterSacred(window) {
+        if (window.is_fullscreen()) {
+            this.handleFullscreenTransition(window);
+            return;
+        }
         if (this._detectBornMaximized(window)) return;
 
         // Born-maximized guard (from onWindowCreated, for subsequent maximize events)
@@ -292,7 +317,7 @@ export const ResizeHandler = GObject.registerClass({
             Logger.log('User entering sacred state, but mosaic is disabled - skipping isolation');
             return;
         }
-        if (!this.windowingManager.isMaximizedOrFullscreen(window) ||
+        if (!window.is_maximized() ||
             this.windowingManager.getMonitorWorkspaceWindows(workspace, monitor).length <= 1) {
             return;
         }
@@ -304,7 +329,7 @@ export const ResizeHandler = GObject.registerClass({
         this._timeoutRegistry.add(constants.SACRED_ENTER_DEBOUNCE_MS, () => {
             WindowState.remove(window, 'sacredEnterPending');
 
-            if (!isWindowAlive(window) || !this.windowingManager.isMaximizedOrFullscreen(window)) {
+            if (!isWindowAlive(window) || !window.is_maximized() || window.is_fullscreen()) {
                 Logger.log(`[SACRED-ENTER] Window ${window.get_id()} already left sacred state - skipping isolation`);
                 return GLib.SOURCE_REMOVE;
             }
@@ -337,11 +362,13 @@ export const ResizeHandler = GObject.registerClass({
         }, 'resizeHandler_sacredEnterDebounce');
     }
 
-    // Mirrors tryEnterSacred: also called from windowHandler's notify::fullscreen
-    // as a backup, in case the size-change signal didn't fire for this exit either.
-    // maximizedUndoInfo gets removed right after use, so calling this twice for the
-    // same exit is safe; the second call just finds nothing left to undo.
+    // maximizedUndoInfo gets removed right after use, so duplicate maximize property
+    // notifications are safe; the second call just finds nothing left to undo.
     tryExitSacred(window) {
+        if (window.is_fullscreen()) {
+            this.handleFullscreenTransition(window);
+            return;
+        }
         // An arrival collision owns this unmaximize and keeps the window in its chosen workspace.
         if (WindowState.get(window, 'workspaceMergeUnmaximize')) {
             return;
@@ -463,6 +490,11 @@ export const ResizeHandler = GObject.registerClass({
     }
 
     _handleMaxUnmaxResize(window) {
+        if (WindowState.get(window, 'fullscreenTransition')) {
+            this._sizeChanged = false;
+            return true;
+        }
+
         if (this.windowingManager.isMaximizedOrFullscreen(window)) {
             WindowState.remove(window, 'isEnteringSacred');
             this._sizeChanged = false;

--- a/extension/resizeHandler.js
+++ b/extension/resizeHandler.js
@@ -319,6 +319,10 @@ export const ResizeHandler = GObject.registerClass({
     // maximizedUndoInfo gets removed right after use, so calling this twice for the
     // same exit is safe; the second call just finds nothing left to undo.
     tryExitSacred(window) {
+        // An arrival collision owns this unmaximize and keeps the window in its chosen workspace.
+        if (WindowState.get(window, 'workspaceMergeUnmaximize')) {
+            return;
+        }
         // Born-maximized windows: don't set unmaximizing flag or try undo
         if (WindowState.get(window, 'openedMaximized')) {
             return;
@@ -441,7 +445,8 @@ export const ResizeHandler = GObject.registerClass({
             return true;
         }
 
-        if (WindowState.get(window, 'unmaximizing')) {
+        if (WindowState.get(window, 'unmaximizing') ||
+            WindowState.get(window, 'workspaceMergeUnmaximize')) {
             this._sizeChanged = false;
             return true;
         }
@@ -559,6 +564,7 @@ export const ResizeHandler = GObject.registerClass({
             WindowState.get(window, 'unmaximizing') ||
             WindowState.get(window, 'isRestoringSacred') ||
             WindowState.get(window, 'openedMaximized') ||
+            WindowState.get(window, 'workspaceMergeUnmaximize') ||
             (WindowState.get(window, 'isMosaicResizing') && !clientOwnedSize);
     }
 

--- a/extension/tiling.js
+++ b/extension/tiling.js
@@ -2807,6 +2807,10 @@ export const TilingManager = GObject.registerClass({
             Logger.log(`savePreferredSize: Skipping for ${window.get_id()} - opened maximized, not yet settled`);
             return true;
         }
+        if (WindowState.get(window, 'workspaceMergeUnmaximize')) {
+            Logger.log(`savePreferredSize: Skipping for ${window.get_id()} - workspace merge in progress`);
+            return true;
+        }
         return false;
     }
 
@@ -3825,4 +3829,3 @@ class Mask {
         }
     }
 }
-

--- a/extension/tiling.js
+++ b/extension/tiling.js
@@ -3363,14 +3363,18 @@ export const TilingManager = GObject.registerClass({
                 WindowState.set(w, 'preferredSize', { width: d.current.width, height: d.current.height });
             WindowState.set(w, 'originalSize', { width: d.current.width, height: d.current.height });
             WindowState.set(w, 'isConstrainedByMosaic', true);
-            this._setSmartResizeTarget(w, sim);
 
             if (d.pendingMiniature) {
+                // A miniature keeps its native frame and only scales its compositor actor.
+                // Recording the visual slot as a resize target would make clamp detection
+                // learn the unchanged frame as a false minimum.
+                WindowState.remove(w, 'targetSmartResizeSize');
                 const storedPreSize = d.pendingPreSize || d.current;
                 pendingWindows.push({ window: w, miniSize: d.miniSize, preSize: storedPreSize });
                 Logger.log(`[MINIATURE] ${w.get_id()} stored in pendingWindows: preSize=${storedPreSize.width}x${storedPreSize.height}, SKIPPING move_resize_frame (will be miniaturized)`);
                 continue;
             }
+            this._setSmartResizeTarget(w, sim);
             this._animateResize(w, frame, sim.width, sim.height, true);
             Logger.log(`[SMART RESIZE] ${sim.id}: ${d.current.width}×${d.current.height} → ${sim.width}×${sim.height}`);
         }

--- a/extension/tiling.js
+++ b/extension/tiling.js
@@ -237,6 +237,10 @@ export const TilingManager = GObject.registerClass({
     // Stamp when a shrink target is applied so the clamp detector can tell "hasn't shrunk yet"
     // (transient) from "won't shrink" (a real minimum), keyed off the target, not the window's age.
     _setSmartResizeTarget(window, size) {
+        // A Smart Resize decision is the final post-unmaximize size. Keeping the earlier
+        // restoration bridge would make the tile pass request one size while clamp detection
+        // waits for another.
+        WindowState.remove(window, 'targetRestoredSize');
         WindowState.set(window, 'targetSmartResizeSize', { width: size.width, height: size.height });
         WindowState.set(window, 'targetSmartResizeSetAt', monotonicNow());
     }
@@ -2676,12 +2680,12 @@ export const TilingManager = GObject.registerClass({
     }
 
     _descriptorSizeForExisting(realWindow) {
-        const restoredSize = WindowState.get(realWindow, 'targetRestoredSize');
-        if (restoredSize) return restoredSize;
-
         // Resize still pending, target not reached yet.
         const smartResizeSize = WindowState.get(realWindow, 'targetSmartResizeSize');
         if (smartResizeSize) return smartResizeSize;
+
+        const restoredSize = WindowState.get(realWindow, 'targetRestoredSize');
+        if (restoredSize) return restoredSize;
 
         // targetSmartResizeSize gets cleared once the frame settles, so use the actual frame
         // here instead of preferredSize.
@@ -3587,19 +3591,19 @@ class WindowDescriptor {
             this.height = miniSize.height;
             Logger.log(`WindowDescriptor: Using miniatureSize ${this.width}x${this.height} for ${meta_window.get_id()}`);
         } else {
-            // Use target dimensions if unmaximizing, as physical frame might still be maximized.
-            const targetSize = WindowState.get(meta_window, 'targetRestoredSize');
             // Use smart resize target dims if move_resize_frame hasn't completed yet.
             const smartResizeSize = WindowState.get(meta_window, 'targetSmartResizeSize');
+            // Use restored dimensions if unmaximizing, as the physical frame might still be maximized.
+            const targetSize = WindowState.get(meta_window, 'targetRestoredSize');
 
-            if (targetSize) {
-                this.width = targetSize.width;
-                this.height = targetSize.height;
-                Logger.log(`WindowDescriptor: Using targetRestoredSize ${this.width}x${this.height} for ${meta_window.get_id()}`);
-            } else if (smartResizeSize) {
+            if (smartResizeSize) {
                 this.width = smartResizeSize.width;
                 this.height = smartResizeSize.height;
                 Logger.log(`WindowDescriptor: Using targetSmartResizeSize ${this.width}x${this.height} for ${meta_window.get_id()}`);
+            } else if (targetSize) {
+                this.width = targetSize.width;
+                this.height = targetSize.height;
+                Logger.log(`WindowDescriptor: Using targetRestoredSize ${this.width}x${this.height} for ${meta_window.get_id()}`);
             } else {
                 this.width = frame.width > 0 ? frame.width : 1;
                 this.height = frame.height > 0 ? frame.height : 1;

--- a/extension/windowHandler.js
+++ b/extension/windowHandler.js
@@ -153,11 +153,13 @@ export const WindowHandler = GObject.registerClass({
                     pendingMaximizeCheck = false;
                     if (!isWindowAlive(win)) return GLib.SOURCE_REMOVE;
 
-                    // Entering/exiting sacred state is owned by resizeHandler, normally
+                    // Entering/exiting maximized state is owned by resizeHandler, normally
                     // driven by the WM size-change signal. This property notify is a
                     // backup for apps where that signal doesn't fire reliably; calling
                     // these twice for the same transition is safe (see resizeHandler.js).
-                    if (this.windowingManager.isMaximizedOrFullscreen(win)) {
+                    if (win.is_fullscreen()) {
+                        this._ext.resizeHandler.handleFullscreenTransition(win);
+                    } else if (win.is_maximized()) {
                         if (!WindowState.get(win, 'openedMaximized') &&
                             !WindowState.get(win, 'workspaceMergeUnmaximize')) {
                             this._ext.resizeHandler.tryEnterSacred(win);
@@ -178,21 +180,11 @@ export const WindowHandler = GObject.registerClass({
             }));
         });
 
-        // Detect Fullscreen changes, same backup pattern as maximize above.
+        // Fullscreen stays on its current workspace. Its frame changes are consumed
+        // without invoking either sacred isolation or a mosaic tile pass.
         ids.push(window.connect('notify::fullscreen', (win) => {
-            if (this.windowingManager.isMaximizedOrFullscreen(win)) {
-                if (!WindowState.get(win, 'openedMaximized')) {
-                    this._ext.resizeHandler.tryEnterSacred(win);
-                }
-            } else if (WindowState.get(win, 'openedMaximized')) {
-                Logger.log(`Window ${win.get_id()} born fullscreen - skipping sacred exit, treating as normal`);
-                WindowState.remove(win, 'openedMaximized');
-                WindowState.remove(win, 'unmaximizing');
-                WindowState.remove(win, 'isEnteringSacred');
-                this._settleBornSacredExit(win, 'unfullscreen');
-            } else {
-                this._ext.resizeHandler.tryExitSacred(win);
-            }
+            this._ext.resizeHandler.handleFullscreenTransition(win);
+            Logger.log(`Window ${win.get_id()} changed fullscreen state in place`);
         }));
 
         ids.push(window.connect('size-changed', (win) => {
@@ -520,10 +512,7 @@ export const WindowHandler = GObject.registerClass({
     _retileAfterWindowGone(removedWindow, remainingWindows, workspace, monitor, freedWidth, freedHeight, options = {}) {
         const opts = this._retileOptions(options);
 
-        if (WindowState.get(removedWindow, 'closeRetileHandledAt')) {
-            Logger.log(`_retileAfterWindowGone: already handled for ${removedWindow.get_id()} - skipping duplicate`);
-            return;
-        }
+        if (this._shouldSkipRetileAfterWindowGone(removedWindow, remainingWindows, opts)) return;
         if (!opts.wasMovedByOverflow)
             WindowState.set(removedWindow, 'closeRetileHandledAt', true);
 
@@ -549,6 +538,18 @@ export const WindowHandler = GObject.registerClass({
         } else {
             this._retileWithoutRestore(workspace, monitor);
         }
+    }
+
+    _shouldSkipRetileAfterWindowGone(removedWindow, remainingWindows, opts) {
+        if (WindowState.get(removedWindow, 'closeRetileHandledAt')) {
+            Logger.log(`_retileAfterWindowGone: already handled for ${removedWindow.get_id()} - skipping duplicate`);
+            return true;
+        }
+        if (opts.wasMovedByOverflow && remainingWindows.some(w => w.is_fullscreen())) {
+            Logger.log('_retileAfterWindowGone: preserving the covered mosaic after overflow from a fullscreen workspace');
+            return true;
+        }
+        return false;
     }
 
     _retileOptions(options) {
@@ -923,17 +924,21 @@ export const WindowHandler = GObject.registerClass({
         return false;
     }
 
-    // Fullscreen remains exclusive. Maximized windows instead give up maximization when an
-    // arrival would make them share a workspace, then join the mosaic at their restored size.
+    // A fullscreen arrival stays over its current mosaic. A normal arrival cannot be
+    // tiled beneath a fullscreen sibling, while maximized siblings join the mosaic.
     async _ensureFitsSacred(window, workspace, monitor) {
         const workspaceWindows = this.windowingManager.getMonitorWorkspaceWindows(workspace, monitor)
             .filter(w => !WindowState.get(w, 'pendingInQueue') && !this.windowingManager.isExcluded(w));
         const otherWindows = workspaceWindows.filter(w => w.get_id() !== window.get_id());
 
-        const fullscreenCollision = (window.is_fullscreen() && otherWindows.length > 0) ||
-            otherWindows.some(w => w.is_fullscreen());
-        if (fullscreenCollision) {
-            Logger.log('Fullscreen collision on arrival - isolating incoming window');
+        if (window.is_fullscreen()) {
+            WindowState.remove(window, 'arrivalPending');
+            this.revealPendingEntrance(window);
+            Logger.log('Fullscreen arrival remains in its current workspace; preserving mosaic layout');
+            return { handled: true, result: workspace };
+        }
+        if (otherWindows.some(w => w.is_fullscreen())) {
+            Logger.log('Workspace has a fullscreen window - moving the normal arrival');
             return { handled: true, result: await this.windowingManager.moveOversizedWindow(window) };
         }
         if (otherWindows.length === 0) return { handled: false, mergedWindows: [] };
@@ -1151,7 +1156,7 @@ export const WindowHandler = GObject.registerClass({
             Logger.log(`Window ${window.get_id()} opened with Shift, set always-on-top`);
         }
 
-        if (this.windowingManager.isMaximizedOrFullscreen(window)) {
+        if (window.is_maximized() && !window.is_fullscreen()) {
             WindowState.set(window, 'openedMaximized', true);
             // Defense: clean up flags that onSizeChange may have set before window-created fired
             WindowState.remove(window, 'maximizedUndoInfo');
@@ -1266,9 +1271,8 @@ export const WindowHandler = GObject.registerClass({
 
         this._captureOpeningSize(window, workspace, monitor);
 
-        if (this.windowingManager.isMaximizedOrFullscreen(window)) {
-            return this._handleSacredCreated(window, workspace, monitor);
-        }
+        const sacredResult = this._handleCreatedSacredState(window, workspace, monitor);
+        if (sacredResult !== null) return sacredResult;
 
         const edgeResult = this._tryTileNewWithEdge(window, workspace, monitor);
         if (edgeResult !== null) return edgeResult;
@@ -1281,6 +1285,14 @@ export const WindowHandler = GObject.registerClass({
 
         this.enqueueWindowForEvaluation(window, workspace, monitor);
         return GLib.SOURCE_REMOVE;
+    }
+
+    _handleCreatedSacredState(window, workspace, monitor) {
+        if (window.is_fullscreen())
+            return this._handleFullscreenCreated(window, workspace);
+        if (window.is_maximized())
+            return this._handleSacredCreated(window, workspace, monitor);
+        return null;
     }
 
     // Use saved_rect for natural size (get_frame_rect matches monitor if Maximized).
@@ -1327,13 +1339,20 @@ export const WindowHandler = GObject.registerClass({
         if (otherWindows.length > 0) {
             // Resolving straight from here would race the queue's own collision
             // check and process the same arrival twice.
-            Logger.log('Opened sacred (Max/Full) in occupied workspace; queueing collision resolution');
+            Logger.log('Opened maximized window in occupied workspace; queueing collision resolution');
             this.enqueueWindowForEvaluation(window, workspace, monitor);
             return GLib.SOURCE_REMOVE;
         }
         Logger.log('Sacred window in empty workspace - keeping here');
         WindowState.remove(window, 'arrivalPending');
         this.tilingManager.tileWorkspaceWindows(workspace, window, monitor, false);
+        return GLib.SOURCE_REMOVE;
+    }
+
+    _handleFullscreenCreated(window, workspace) {
+        WindowState.remove(window, 'arrivalPending');
+        this.revealPendingEntrance(window);
+        Logger.log(`Fullscreen window ${window.get_id()} remains in workspace ${workspace.index()}; preserving mosaic layout`);
         return GLib.SOURCE_REMOVE;
     }
 

--- a/extension/windowHandler.js
+++ b/extension/windowHandler.js
@@ -994,6 +994,7 @@ export const WindowHandler = GObject.registerClass({
     _settleWorkspaceMerge(windows) {
         for (const window of windows) {
             this._timeoutRegistry.add(constants.RETILE_DELAY_MS + constants.RESIZE_SETTLE_DELAY_MS, () => {
+                this._captureWorkspaceMergeSize(window);
                 WindowState.remove(window, 'workspaceMergeUnmaximize');
                 WindowState.remove(window, 'openedMaximized');
                 WindowState.remove(window, 'isEnteringSacred');
@@ -1002,6 +1003,35 @@ export const WindowHandler = GObject.registerClass({
                 return GLib.SOURCE_REMOVE;
             }, 'windowHandler_workspaceMergeSettle');
         }
+    }
+
+    _captureWorkspaceMergeSize(window) {
+        const context = this._workspaceMergeSizeContext(window);
+        if (!context) return;
+
+        const { frame, workArea } = context;
+        const isMonitorSized = frame.width >= workArea.width && frame.height >= workArea.height;
+        const size = isMonitorSized
+            ? { width: Math.floor(workArea.width * 0.8), height: Math.floor(workArea.height * 0.8) }
+            : { width: frame.width, height: frame.height };
+        WindowState.set(window, 'preferredSize', size);
+        Logger.log(`Workspace merge: captured preferred size for ${window.get_id()}: ${size.width}x${size.height}${isMonitorSized ? ' (80% fallback)' : ''}`);
+    }
+
+    _workspaceMergeSizeContext(window) {
+        if (!isWindowAlive(window)) return null;
+        if (WindowState.get(window, 'preferredSize') || WindowState.get(window, 'openingSize')) return null;
+
+        const workspace = window.get_workspace();
+        const monitor = window.get_monitor();
+        if (!workspace || monitor === null || monitor < 0) return null;
+
+        const workArea = workspace.get_work_area_for_monitor(monitor);
+        if (!workArea) return null;
+
+        const frame = window.get_frame_rect();
+        if (frame.width <= 0 || frame.height <= 0) return null;
+        return { frame, workArea };
     }
 
     _handleDnDArrival(window, workspace, monitor) {

--- a/extension/windowHandler.js
+++ b/extension/windowHandler.js
@@ -158,9 +158,12 @@ export const WindowHandler = GObject.registerClass({
                     // backup for apps where that signal doesn't fire reliably; calling
                     // these twice for the same transition is safe (see resizeHandler.js).
                     if (this.windowingManager.isMaximizedOrFullscreen(win)) {
-                        if (!WindowState.get(win, 'openedMaximized')) {
+                        if (!WindowState.get(win, 'openedMaximized') &&
+                            !WindowState.get(win, 'workspaceMergeUnmaximize')) {
                             this._ext.resizeHandler.tryEnterSacred(win);
                         }
+                    } else if (WindowState.get(win, 'workspaceMergeUnmaximize')) {
+                        Logger.log(`Window ${win.get_id()} unmaximized to join an occupied workspace`);
                     } else if (WindowState.get(win, 'openedMaximized')) {
                         Logger.log(`Window ${win.get_id()} born maximized - skipping sacred exit, treating as normal unmaximize`);
                         WindowState.remove(win, 'openedMaximized');
@@ -873,31 +876,35 @@ export const WindowHandler = GObject.registerClass({
         const sacred = await this._ensureFitsSacred(window, workspace, monitor);
         if (sacred.handled) return sacred.result;
 
-        // Already constrained, so sibling frames may not have settled yet; tile directly to avoid false overflow.
-        if (WindowState.get(window, 'isConstrainedByMosaic')) {
-            Logger.log(`ensureWindowFits: Window ${window.get_id()} already constrained by mosaic - tiling directly`);
-            this.tilingManager.tileWorkspaceWindows(workspace, null, monitor, false);
-            return workspace;
+        try {
+            // Already constrained, so sibling frames may not have settled yet; tile directly to avoid false overflow.
+            if (WindowState.get(window, 'isConstrainedByMosaic')) {
+                Logger.log(`ensureWindowFits: Window ${window.get_id()} already constrained by mosaic - tiling directly`);
+                this.tilingManager.tileWorkspaceWindows(workspace, null, monitor, false);
+                return workspace;
+            }
+
+            // Save preferred size after sacred checks, to avoid capturing monitor-sized dimensions
+            this.tilingManager.savePreferredSize(window);
+
+            if (arrivedFromDnD) {
+                this._handleDnDArrival(window, workspace, monitor);
+            }
+
+            // Use TARGET size for restoration flows to avoid transient overflow ejection.
+            const targetSize = WindowState.get(window, 'targetRestoredSize');
+            const canFit = this.tilingManager.canFitWindow(window, workspace, monitor, false, targetSize);
+
+            if (canFit) {
+                Logger.log('Window fits - tiling workspace directly');
+                this.tilingManager.tileWorkspaceWindows(workspace, null, monitor, false);
+                return workspace;
+            }
+
+            return await this._fitByResizeOrOverflow(window, workspace, monitor);
+        } finally {
+            this._settleWorkspaceMerge(sacred.mergedWindows);
         }
-
-        // Save preferred size after sacred checks, to avoid capturing monitor-sized dimensions
-        this.tilingManager.savePreferredSize(window);
-
-        if (arrivedFromDnD) {
-            this._handleDnDArrival(window, workspace, monitor);
-        }
-
-        // Use TARGET size for restoration flows to avoid transient overflow ejection.
-        const targetSize = WindowState.get(window, 'targetRestoredSize');
-        const canFit = this.tilingManager.canFitWindow(window, workspace, monitor, false, targetSize);
-
-        if (canFit) {
-            Logger.log('Window fits - tiling workspace directly');
-            this.tilingManager.tileWorkspaceWindows(workspace, null, monitor, false);
-            return workspace;
-        }
-
-        return await this._fitByResizeOrOverflow(window, workspace, monitor);
     }
 
     _ensureFitsBlocked(window, workspace) {
@@ -916,20 +923,85 @@ export const WindowHandler = GObject.registerClass({
         return false;
     }
 
-    // A sacred (maximized/fullscreen) arrival, or a normal one landing where a sacred window
-    // already lives, gets its own workspace. {handled:true, result} when isolated.
+    // Fullscreen remains exclusive. Maximized windows instead give up maximization when an
+    // arrival would make them share a workspace, then join the mosaic at their restored size.
     async _ensureFitsSacred(window, workspace, monitor) {
-        const isIncomingSacred = this.windowingManager.isMaximizedOrFullscreen(window);
-        const hasExistingSacred = this.windowingManager.hasSacredWindow(workspace, monitor, window.get_id());
         const workspaceWindows = this.windowingManager.getMonitorWorkspaceWindows(workspace, monitor)
-            .filter(w => !WindowState.get(w, 'pendingInQueue'));
+            .filter(w => !WindowState.get(w, 'pendingInQueue') && !this.windowingManager.isExcluded(w));
         const otherWindows = workspaceWindows.filter(w => w.get_id() !== window.get_id());
 
-        if (hasExistingSacred || (isIncomingSacred && otherWindows.length > 0)) {
-            Logger.log(`Sacred Isolation triggered (IncomingSacred: ${isIncomingSacred}, HasExistingSacred: ${hasExistingSacred}) - isolating`);
+        const fullscreenCollision = (window.is_fullscreen() && otherWindows.length > 0) ||
+            otherWindows.some(w => w.is_fullscreen());
+        if (fullscreenCollision) {
+            Logger.log('Fullscreen collision on arrival - isolating incoming window');
             return { handled: true, result: await this.windowingManager.moveOversizedWindow(window) };
         }
-        return { handled: false };
+        if (otherWindows.length === 0) return { handled: false, mergedWindows: [] };
+
+        const maximizedWindows = workspaceWindows.filter(w => w.is_maximized() && !w.is_fullscreen());
+        if (maximizedWindows.length === 0) return { handled: false, mergedWindows: [] };
+
+        Logger.log(`Workspace merge: unmaximizing ${maximizedWindows.length} window(s) before tiling`);
+        await Promise.all(maximizedWindows.map(w => this._unmaximizeForWorkspaceMerge(w)));
+        return { handled: false, mergedWindows: maximizedWindows };
+    }
+
+    _unmaximizeForWorkspaceMerge(window) {
+        const restoredSize = WindowState.get(window, 'preferredSize') ||
+            WindowState.get(window, 'openingSize');
+        if (restoredSize)
+            WindowState.set(window, 'targetRestoredSize', restoredSize);
+
+        WindowState.set(window, 'workspaceMergeUnmaximize', true);
+
+        return new Promise(resolve => {
+            const signalIds = [];
+            let timeoutId = null;
+            let settled = false;
+
+            const finish = () => {
+                if (settled) return;
+                settled = true;
+                for (const id of signalIds) window.disconnect(id);
+                if (timeoutId) this._timeoutRegistry.remove(timeoutId);
+                resolve();
+            };
+            const check = () => {
+                if (!isWindowAlive(window) || !window.is_maximized()) finish();
+            };
+
+            signalIds.push(window.connect('notify::maximized-horizontally', check));
+            signalIds.push(window.connect('notify::maximized-vertically', check));
+            signalIds.push(window.connect('unmanaged', finish));
+            timeoutId = this._timeoutRegistry.add(constants.SACRED_RESTORE_SAFETY_TIMEOUT_MS, () => {
+                Logger.warn(`Workspace merge: timed out waiting for ${window.get_id()} to unmaximize`);
+                finish();
+                return GLib.SOURCE_REMOVE;
+            }, 'windowHandler_workspaceMergeUnmaximize');
+
+            if (this.edgeTilingManager.isEdgeTiled(window)) {
+                this.edgeTilingManager.removeTile(window);
+            } else {
+                window.unmaximize();
+            }
+
+            // A workspace chosen by the user supersedes the old sacred return target.
+            WindowState.remove(window, 'maximizedUndoInfo');
+            check();
+        });
+    }
+
+    _settleWorkspaceMerge(windows) {
+        for (const window of windows) {
+            this._timeoutRegistry.add(constants.RETILE_DELAY_MS + constants.RESIZE_SETTLE_DELAY_MS, () => {
+                WindowState.remove(window, 'workspaceMergeUnmaximize');
+                WindowState.remove(window, 'openedMaximized');
+                WindowState.remove(window, 'isEnteringSacred');
+                WindowState.remove(window, 'unmaximizing');
+                WindowState.remove(window, 'targetRestoredSize');
+                return GLib.SOURCE_REMOVE;
+            }, 'windowHandler_workspaceMergeSettle');
+        }
     }
 
     _handleDnDArrival(window, workspace, monitor) {
@@ -1219,12 +1291,13 @@ export const WindowHandler = GObject.registerClass({
 
         this.windowingManager.invalidateWindowsCache();
         const workspaceWindows = this.windowingManager.getMonitorWorkspaceWindows(workspace, monitor);
-        const otherWindows = workspaceWindows.filter(w => w.get_id() !== window.get_id());
+        const otherWindows = workspaceWindows.filter(w =>
+            w.get_id() !== window.get_id() && !this.windowingManager.isExcluded(w));
 
         if (otherWindows.length > 0) {
-            // Isolating straight from here would race the queue's own sacred
-            // check and isolate twice, each pass creating its own workspace.
-            Logger.log('Opened sacred (Max/Full) in occupied workspace; queueing for isolation (SACRED)');
+            // Resolving straight from here would race the queue's own collision
+            // check and process the same arrival twice.
+            Logger.log('Opened sacred (Max/Full) in occupied workspace; queueing collision resolution');
             this.enqueueWindowForEvaluation(window, workspace, monitor);
             return GLib.SOURCE_REMOVE;
         }

--- a/extension/windowing.js
+++ b/extension/windowing.js
@@ -201,6 +201,12 @@ export const WindowingManager = GObject.registerClass({
     }
 
     moveOversizedWindow(window, options = { switchFocus: true }) {
+        if (window.is_fullscreen()) {
+            const workspace = window.get_workspace();
+            Logger.log(`moveOversizedWindow: Keeping fullscreen window ${window.get_id()} in workspace ${workspace?.index()}`);
+            return Promise.resolve(workspace);
+        }
+
         return new Promise(resolve => {
             const workspaceManager = global.workspace_manager;
             const monitor = window.get_monitor();


### PR DESCRIPTION
## Description

This PR fixes workspace handling when maximized or fullscreen windows interact
with occupied mosaic workspaces.

Maximized windows are unmaximized when they need to join an existing mosaic,
while explicit user maximization continues to isolate the window. Fullscreen
windows remain on their current workspace without changing the underlying
mosaic layout.

### Fixes / Improvements

- [x] Unmaximize existing maximized windows when another window joins
- [x] Unmaximize maximized arrivals before adding them to a mosaic
- [x] Preserve explicit maximization behavior
- [x] Handle applications that open maximized
- [x] Keep fullscreen windows on their current workspace
- [x] Preserve the covered mosaic during fullscreen transitions

## Related Issues

Closes #117 

## Validation

- [x] `npm run lint`
- [x] `./scripts/build.sh -b`
- [x] Tested on GNOME Shell 50.1 under Wayland
- [x] Verified explicit fullscreen and unfullscreen
- [x] Verified a window launched fullscreen in an occupied workspace
- [x] Verified maximized-window workspace merges